### PR TITLE
Refactor CLI to subcommands with read/check/download support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,14 +142,12 @@ The wrapper adds:
 
 ### Local Development Path
 
-Lines 56-58 in `herd_mail.py` add local waggle dev path if present:
-```python
-LOCAL_WAGGLE = Path("/Volumes/RayCue-Drive/Documents/openclaw/.openclaw/workspace/projects/waggle")
-if LOCAL_WAGGLE.exists():
-    sys.path.insert(0, str(LOCAL_WAGGLE))
+Set the `WAGGLE_DEV_PATH` environment variable to use a local waggle checkout:
+```bash
+export WAGGLE_DEV_PATH=/path/to/local/waggle
 ```
 
-This allows testing unreleased waggle changes. Remove or adjust this path if it causes issues.
+This is intentionally opt-in for security — no hardcoded paths.
 
 ## Code Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,50 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-herd-mail is a CLI wrapper for [waggle](https://github.com/jasonacox-sam/waggle-mail) designed for AI-to-AI email communication. It handles Markdown→HTML conversion, threading, duplicate prevention, and IMAP Sent folder synchronization.
+herd-mail is a CLI wrapper for [waggle](https://github.com/jasonacox-sam/waggle-mail) designed for AI-to-AI email communication. It handles Markdown→HTML conversion, threading, duplicate prevention, IMAP Sent folder synchronization, and message reading with attachment downloads.
 
 This is a standalone Python script, not a package. No build system or setup.py required.
+
+**Version 3.0**: Subcommand-based CLI for sending and reading email. JSON-first output for AI agents (stdout=JSON, stderr=logging).
 
 ## Development Commands
 
 ### Running the script
 ```bash
 # Requires environment setup first (see Configuration below)
-python3 herd_mail.py --to recipient@example.com --subject "Test" --body "Hello"
 
-# With markdown file
-python3 herd_mail.py --to recipient@example.com --subject "Test" --body-file message.md
+# Validate configuration
+python3 herd_mail.py config
+
+# Send a simple email
+python3 herd_mail.py send --to recipient@example.com --subject "Test" --body "Hello"
+
+# Send with markdown file
+python3 herd_mail.py send --to recipient@example.com --subject "Test" --body-file message.md
 
 # Reply to message (thread-aware)
-python3 herd_mail.py --message-id 42 --to sender@example.com --subject "Re: Hello"
+python3 herd_mail.py send --message-id 42 --to sender@example.com --subject "Re: Hello"
 
-# Validate configuration without sending
-python3 herd_mail.py --dry-run
+# List messages (JSON output for AI agents)
+python3 herd_mail.py list
+
+# List unread only, human-readable
+python3 herd_mail.py list --unread --human
+
+# Read a specific message
+python3 herd_mail.py read <uid>
+
+# Read with human-readable formatting
+python3 herd_mail.py read <uid> --human
+
+# Check for unread messages (exit 0=has unread, 1=none, 2=error)
+python3 herd_mail.py check
+
+# Download attachments from a message
+python3 herd_mail.py download <uid> --dest-dir ./attachments
+
+# Backward compatibility: old style still works with deprecation warning
+python3 herd_mail.py --to recipient@example.com --subject "Test" --body "Hello"
 ```
 
 ### Testing
@@ -39,6 +64,8 @@ python3 test_herd_mail.py
 ```
 
 Tests mock SMTP/IMAP so they run without real credentials.
+
+**Test Coverage**: ~95% | **Tests**: 61 passing
 
 ### Dependencies
 ```bash
@@ -66,7 +93,21 @@ Optional vars: See `.envrc.template` for full list (IMAP settings, send log path
 
 ## Architecture
 
-### Core Flow
+### Subcommand Dispatch Pattern
+
+Version 3.0 uses a subcommand-based CLI with dedicated handlers:
+- `cmd_config()` - Validate configuration
+- `cmd_send()` - Send emails (old default behavior)
+- `cmd_list()` - List messages from IMAP
+- `cmd_read()` - Read a specific message
+- `cmd_check()` - Check for unread messages (polling-friendly exit codes)
+- `cmd_download()` - Download attachments from a message
+
+**Output Design**: JSON to stdout (for AI agents), logging to stderr. This allows piping JSON directly to other tools while preserving debug output visibility.
+
+**Backward Compatibility**: Old-style `herd_mail.py --to ...` invokes `cmd_send()` with a deprecation warning on stderr.
+
+### Core Flow (Send)
 1. **Config Loading** (`get_config()`) - Read env vars with defaults
 2. **Validation** (`validate_config()`) - Check required fields present
 3. **Duplicate Check** (optional) - Query send log via waggle
@@ -75,6 +116,13 @@ Optional vars: See `.envrc.template` for full list (IMAP settings, send log path
 6. **Send** - SMTP delivery via waggle's `send_email()`
 7. **IMAP Sync** - Save copy to Sent folder (if IMAP configured)
 8. **Logging** - Record send for duplicate detection
+
+### Core Flow (Read)
+1. **Config Loading & Validation** - Same as send flow
+2. **IMAP Connection** - Connect using waggle's IMAP helpers
+3. **List/Read/Check** - Fetch messages, parse content
+4. **Attachment Download** (optional) - Save attachments to disk with validation
+5. **JSON Output** - Structured output to stdout for AI agent consumption
 
 ### waggle Integration
 
@@ -86,8 +134,11 @@ This script is a thin wrapper around waggle's core functions:
 The wrapper adds:
 - Environment-based configuration
 - Config validation with helpful error messages
-- CLI argument parsing
+- Subcommand-based CLI argument parsing
 - Thread-aware reply handling
+- JSON-first output for AI agents
+- Message listing and reading
+- Attachment download with path validation
 
 ### Local Development Path
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
 # herd-mail 🐝
 
-**Version 2.0** — Production-ready, security-hardened email CLI
+**Version 3.0** — Production-ready, security-hardened email CLI with reading and sending
 
 AI-to-AI communication facilitator for the herd.
 
-A secure, user-friendly CLI wrapper for [waggle](https://github.com/jasonacox-sam/waggle) that handles the full lifecycle of herd email communication: configuration, threading, duplication prevention, and sent-folder synchronization.
+A secure, user-friendly CLI wrapper for [waggle](https://github.com/jasonacox-sam/waggle) that handles the full lifecycle of herd email communication: sending with threading and duplicate prevention, reading with JSON output for AI agents, attachment downloads, and sent-folder synchronization.
 
 ## Features
 
+### Sending
 - **Markdown → HTML**: Write emails in Markdown, get beautiful HTML + plain text
 - **Thread-aware Replies**: Auto-fetch original messages for proper threading
 - **Attachments**: Send files with security validation
 - **Duplicate Prevention**: Checks send log to prevent accidental resends
 - **Sent Folder Sync**: Automatically saves to IMAP Sent folder
+
+### Reading
+- **List Messages**: JSON output for AI agents, human-readable for interactive use
+- **Read Messages**: Full message content with headers
+- **Check for Unread**: Polling-friendly exit codes (0=has unread, 1=none, 2=error)
+- **Download Attachments**: Save attachments with path validation
+
+### General
+- **Subcommand CLI**: `send`, `list`, `read`, `check`, `download`, `config`
+- **JSON-first Output**: Stdout for data, stderr for logging (AI-agent friendly)
 - **Environment-based**: No hardcoded credentials in scripts
 - **Security Hardened**: Email validation, path validation, injection prevention
 - **Type Safe**: Full type hints for Python 3.8+
+- **Backward Compatible**: Old `--to` syntax still works with deprecation warning
 
 ## Quick Start
 
@@ -36,10 +48,10 @@ cp .envrc.template .envrc
 source .envrc
 
 # Validate configuration
-python3 herd_mail.py --dry-run
+python3 herd_mail.py config
 
 # Send a test email
-python3 herd_mail.py --to friend@example.com --subject "Hello" --body "Hi from herd-mail!"
+python3 herd_mail.py send --to friend@example.com --subject "Hello" --body "Hi from herd-mail!"
 ```
 
 ## Installation
@@ -104,10 +116,18 @@ cp .envrc.template .envrc
 
 ## Usage
 
+### Validate Configuration
+
+Check that all required environment variables are set:
+
+```bash
+python3 herd_mail.py config
+```
+
 ### Send a Simple Email
 
 ```bash
-python3 herd_mail.py \
+python3 herd_mail.py send \
   --to friend@example.com \
   --subject "Hello from herd-mail" \
   --body "This is a test email!"
@@ -116,7 +136,7 @@ python3 herd_mail.py \
 ### Send with Markdown Body from File
 
 ```bash
-python3 herd_mail.py \
+python3 herd_mail.py send \
   --to friend@example.com \
   --subject "Weekly Update" \
   --body-file message.md
@@ -143,7 +163,7 @@ def hello():
 ### Reply to a Message (Threading)
 
 ```bash
-python3 herd_mail.py \
+python3 herd_mail.py send \
   --message-id 42 \
   --to sender@example.com \
   --subject "Re: Original Subject" \
@@ -158,7 +178,7 @@ This automatically:
 ### Send with Attachment
 
 ```bash
-python3 herd_mail.py \
+python3 herd_mail.py send \
   --to friend@example.com \
   --subject "Document" \
   --body "See attached" \
@@ -168,7 +188,7 @@ python3 herd_mail.py \
 Multiple attachments:
 
 ```bash
-python3 herd_mail.py \
+python3 herd_mail.py send \
   --to friend@example.com \
   --subject "Files" \
   --attachment file1.pdf file2.txt file3.png
@@ -177,7 +197,7 @@ python3 herd_mail.py \
 ### Rich HTML Formatting
 
 ```bash
-python3 herd_mail.py \
+python3 herd_mail.py send \
   --to friend@example.com \
   --subject "Code Review" \
   --body-file code-review.md \
@@ -189,31 +209,114 @@ Adds syntax highlighting for code blocks.
 ### Pipe Body from Stdin
 
 ```bash
-cat message.txt | python3 herd_mail.py \
+cat message.txt | python3 herd_mail.py send \
   --to friend@example.com \
   --subject "Hello"
 ```
 
-### Validate Configuration (Dry Run)
+## Reading Mail
+
+### List Messages
+
+JSON output (for AI agents):
 
 ```bash
-python3 herd_mail.py --dry-run
+python3 herd_mail.py list
 ```
 
-Checks that all required environment variables are set without sending. Validates email addresses and port numbers.
+Human-readable output:
+
+```bash
+python3 herd_mail.py list --human
+```
+
+List only unread messages:
+
+```bash
+python3 herd_mail.py list --unread --human
+```
+
+### Read a Specific Message
+
+```bash
+# JSON output
+python3 herd_mail.py read 42
+
+# Human-readable
+python3 herd_mail.py read 42 --human
+```
+
+### Check for Unread Messages
+
+Useful for polling loops. Exit codes:
+- `0` - Has unread messages
+- `1` - No unread messages
+- `2` - Error
+
+```bash
+if python3 herd_mail.py check; then
+    echo "You have unread messages"
+    python3 herd_mail.py list --unread
+fi
+```
+
+### Download Attachments
+
+```bash
+# Download to current directory
+python3 herd_mail.py download 42
+
+# Download to specific directory
+python3 herd_mail.py download 42 --dest-dir ./attachments
+```
+
+### Backward Compatibility
+
+Old-style syntax still works with a deprecation warning:
+
+```bash
+# This works but shows a warning
+python3 herd_mail.py --to friend@example.com --subject "Hello" --body "Hi!"
+```
+
+Recommended to use `send` subcommand instead.
 
 ## Command Line Reference
 
-```
-usage: herd_mail.py [-h] --to TO --subject SUBJECT [--body BODY] [--body-file BODY_FILE]
-                    [--attachment ATTACHMENT [ATTACHMENT ...]] [--cc CC]
-                    [--reply-to REPLY_TO] [--message-id MESSAGE_ID] [--rich]
-                    [--skip-duplicate-check] [--dry-run]
+### Main Command
 
-Send herd emails with Markdown, attachments, and threading via waggle
+```
+usage: herd_mail.py [-h] {config,send,list,read,check,download} ...
+
+herd-mail: AI-to-AI email communication via waggle
+
+subcommands:
+  {config,send,list,read,check,download}
+    config              Validate configuration
+    send                Send an email
+    list                List messages
+    read                Read a specific message
+    check               Check for unread messages (exit 0=has unread, 1=none, 2=error)
+    download            Download attachments from a message
+```
+
+### config subcommand
+
+```
+usage: herd_mail.py config [-h]
+
+Validate configuration without connecting
+```
+
+### send subcommand
+
+```
+usage: herd_mail.py send [-h] --to TO --subject SUBJECT [--body BODY]
+                         [--body-file BODY_FILE] [--attachment ATTACHMENT [ATTACHMENT ...]]
+                         [--cc CC] [--reply-to REPLY_TO] [--message-id MESSAGE_ID]
+                         [--rich] [--skip-duplicate-check]
 
 options:
-  -h, --help            show this help message and exit
   --to TO               Recipient email address
   --subject SUBJECT     Email subject line
   --body BODY           Email body (Markdown supported)
@@ -225,11 +328,54 @@ options:
   --reply-to REPLY_TO   Reply-To address
   --message-id MESSAGE_ID
                         IMAP message ID to reply to (enables threading)
-  --rich                Enable rich HTML formatting (requires markdown,
-                        pygments)
+  --rich                Enable rich HTML formatting
   --skip-duplicate-check
                         Skip checking for recent duplicates
-  --dry-run             Validate config without sending
+```
+
+### list subcommand
+
+```
+usage: herd_mail.py list [-h] [--unread] [--human]
+
+options:
+  --unread              Show only unread messages
+  --human               Human-readable output (default: JSON)
+```
+
+### read subcommand
+
+```
+usage: herd_mail.py read [-h] [--human] uid
+
+positional arguments:
+  uid         Message UID to read
+
+options:
+  --human     Human-readable output (default: JSON)
+```
+
+### check subcommand
+
+```
+usage: herd_mail.py check [-h]
+
+Check for unread messages. Exit codes:
+  0 - Has unread messages
+  1 - No unread messages
+  2 - Error
+```
+
+### download subcommand
+
+```
+usage: herd_mail.py download [-h] [--dest-dir DEST_DIR] uid
+
+positional arguments:
+  uid                   Message UID to download attachments from
+
+options:
+  --dest-dir DEST_DIR   Destination directory (default: current directory)
 ```
 
 ## Testing
@@ -247,9 +393,11 @@ python3 test_herd_mail.py
 
 Tests mock SMTP/IMAP so they run without real credentials.
 
-**Test Coverage**: ~95% | **Tests**: 30 passing
+**Test Coverage**: ~95% | **Tests**: 61 passing
 
 ## How It Works
+
+### Sending Flow
 
 1. **Load Configuration**: Read environment variables with validation
 2. **Validate Inputs**: Check email addresses, ports, and file paths
@@ -259,6 +407,21 @@ Tests mock SMTP/IMAP so they run without real credentials.
 6. **Send**: SMTP delivery via waggle
 7. **Save Copy**: IMAP append to Sent folder (optional)
 8. **Log**: Record send for duplicate detection
+
+### Reading Flow
+
+1. **Load Configuration**: Read environment variables with validation
+2. **Connect to IMAP**: Establish secure connection
+3. **Fetch Messages**: Query inbox for messages
+4. **Parse Content**: Extract headers, body, attachments
+5. **Output JSON**: Structured data to stdout (stderr for logging)
+6. **Download Attachments** (optional): Save to disk with path validation
+
+### Output Design
+
+- **stdout**: JSON output for AI agents to parse
+- **stderr**: Human-readable logging and error messages
+- This separation allows piping JSON directly to other tools while preserving debug visibility
 
 ## Security Features
 
@@ -339,7 +502,7 @@ For testing unreleased waggle changes:
 
 ```bash
 export WAGGLE_DEV_PATH=/path/to/local/waggle
-python3 herd_mail.py --dry-run
+python3 herd_mail.py config
 ```
 
 This is intentionally opt-in for security.
@@ -349,7 +512,8 @@ This is intentionally opt-in for security.
 - **Type Hints**: Full type annotations for Python 3.8+
 - **Logging**: Professional logging infrastructure (not print statements)
 - **Error Handling**: Specific exception types with helpful messages
-- **Testing**: 95% test coverage with 30 test cases
+- **Testing**: 95% test coverage with 61 test cases
+- **Architecture**: Subcommand dispatch pattern with cmd_* handlers
 
 ## Contributing
 
@@ -371,4 +535,4 @@ MIT — same as waggle
 
 ---
 
-**Status**: ✅ Production Ready | **Version**: 2.0.0 | **Security**: Hardened | **Tests**: 30/30 Passing
+**Status**: ✅ Production Ready | **Version**: 3.0.0 | **Security**: Hardened | **Tests**: 61/61 Passing

--- a/docs/superpowers/plans/2026-03-26-subcommand-refactor.md
+++ b/docs/superpowers/plans/2026-03-26-subcommand-refactor.md
@@ -1,0 +1,1655 @@
+# Subcommand Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor herd_mail.py from flat flags to subcommands (send, list, read, check, download, config) with JSON-first output for AI agent consumption.
+
+**Architecture:** Single-file refactor. Extract current send logic into `cmd_send`, add new `cmd_list`/`cmd_read`/`cmd_check`/`cmd_download`/`cmd_config` handlers that wrap waggle functions. Subcommand dispatch in `main()` with backward-compat fallback for `--to` without subcommand.
+
+**Tech Stack:** Python 3.8+, argparse subparsers, waggle (list_inbox, read_message, download_attachments), json module for output.
+
+---
+
+### File Map
+
+- **Modify:** `herd_mail.py` — refactor main(), add command handlers, output helpers, new imports
+- **Modify:** `test_herd_mail.py` — update existing send tests to use subcommand argv, add new test classes
+
+---
+
+### Task 1: Add waggle stubs and imports for new functions
+
+**Files:**
+- Modify: `herd_mail.py:86-106` (import block and stubs)
+
+- [ ] **Step 1: Write test for new stub availability**
+
+Add to `test_herd_mail.py` at the end of existing test classes (before `run_basic_tests`):
+
+```python
+class TestWaggleStubs(unittest.TestCase):
+    """Test that waggle function stubs exist for mocking."""
+
+    def test_stubs_exist(self):
+        """All waggle functions should be importable from herd_mail."""
+        self.assertTrue(hasattr(hm, 'send_email'))
+        self.assertTrue(hasattr(hm, 'check_recently_sent'))
+        self.assertTrue(hasattr(hm, 'read_message'))
+        self.assertTrue(hasattr(hm, 'list_inbox'))
+        self.assertTrue(hasattr(hm, 'download_attachments'))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest test_herd_mail.py::TestWaggleStubs -v`
+Expected: FAIL — `list_inbox` and `download_attachments` not found on module
+
+- [ ] **Step 3: Update imports and stubs in herd_mail.py**
+
+Replace lines 86-106 in `herd_mail.py` with:
+
+```python
+# Try to import waggle, but don't exit at module level (allows tests to run)
+WAGGLE_AVAILABLE = False
+WAGGLE_IMPORT_ERROR = None
+
+try:
+    from waggle import (
+        send_email, check_recently_sent, read_message,
+        list_inbox, download_attachments,
+    )
+    WAGGLE_AVAILABLE = True
+except ImportError as e:
+    WAGGLE_IMPORT_ERROR = e
+
+    def send_email(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+
+    def check_recently_sent(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+
+    def read_message(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+
+    def list_inbox(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+
+    def download_attachments(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest test_herd_mail.py::TestWaggleStubs -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full suite to verify no regressions**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: 31 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Add waggle list_inbox and download_attachments imports and stubs"
+```
+
+---
+
+### Task 2: Add `require_imap` to validate_config
+
+**Files:**
+- Modify: `herd_mail.py:341-372` (validate_config function)
+- Modify: `test_herd_mail.py` (TestConfig class)
+
+- [ ] **Step 1: Write tests for IMAP validation**
+
+Add to `TestConfig` class in `test_herd_mail.py`:
+
+```python
+    def test_validate_config_require_imap_missing(self):
+        """Test validation fails when IMAP required but missing."""
+        cfg = {
+            "smtp_host": "smtp.example.com",
+            "smtp_user": "user@example.com",
+            "smtp_pass": "secret",
+            "from_addr": "user@example.com",
+            "imap_host": None,
+        }
+        result = hm.validate_config(cfg, require_smtp=False, require_imap=True)
+        self.assertFalse(result)
+
+    def test_validate_config_require_imap_present(self):
+        """Test validation passes when IMAP required and present."""
+        cfg = {
+            "smtp_host": "smtp.example.com",
+            "smtp_user": "user@example.com",
+            "smtp_pass": "secret",
+            "from_addr": "user@example.com",
+            "imap_host": "imap.example.com",
+        }
+        result = hm.validate_config(cfg, require_smtp=False, require_imap=True)
+        self.assertTrue(result)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_herd_mail.py::TestConfig::test_validate_config_require_imap_missing test_herd_mail.py::TestConfig::test_validate_config_require_imap_present -v`
+Expected: FAIL — `validate_config() got an unexpected keyword argument 'require_imap'`
+
+- [ ] **Step 3: Update validate_config**
+
+Replace the `validate_config` function in `herd_mail.py`:
+
+```python
+def validate_config(cfg: dict[str, Any], require_smtp: bool = True, require_imap: bool = False) -> bool:
+    """
+    Validate configuration has required values.
+
+    Args:
+        cfg: Configuration dictionary
+        require_smtp: Whether to require SMTP settings
+        require_imap: Whether to require IMAP settings
+
+    Returns:
+        True if valid, False otherwise
+    """
+    errors = []
+
+    if require_smtp:
+        required = ["smtp_host", "smtp_user", "smtp_pass", "from_addr"]
+        for key in required:
+            if not cfg.get(key):
+                errors.append(f"Missing {key} (set WAGGLE_{key.upper()})")
+
+        from_addr = cfg.get("from_addr")
+        if from_addr and not validate_email_address(from_addr):
+            errors.append(f"Invalid from_addr email format: {from_addr}")
+
+    if require_imap:
+        if not cfg.get("imap_host"):
+            errors.append("Missing imap_host (set WAGGLE_IMAP_HOST)")
+
+    if errors:
+        logger.error("Configuration errors:")
+        for error in errors:
+            logger.error(f"  - {error}")
+        logger.error("\nSee .envrc.template for required variables.")
+        return False
+
+    return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_herd_mail.py::TestConfig -v`
+Expected: 7 passed
+
+- [ ] **Step 5: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: 33 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Add require_imap parameter to validate_config"
+```
+
+---
+
+### Task 3: Add output helpers (output_json, human formatters)
+
+**Files:**
+- Modify: `herd_mail.py` — add after `build_waggle_config`, before `main()`
+- Modify: `test_herd_mail.py` — new TestOutput class
+
+- [ ] **Step 1: Write tests for output helpers**
+
+Add new import at top of `test_herd_mail.py`:
+
+```python
+import json
+```
+
+Add new test class:
+
+```python
+class TestOutput(unittest.TestCase):
+    """Test output formatting helpers."""
+
+    def test_output_json(self):
+        """Test JSON output goes to stdout."""
+        data = {"folder": "INBOX", "count": 1, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_json(data)
+        result = json.loads(captured.getvalue())
+        self.assertEqual(result["folder"], "INBOX")
+        self.assertEqual(result["count"], 1)
+
+    def test_output_human_list_with_messages(self):
+        """Test human-readable list output."""
+        data = {
+            "folder": "INBOX",
+            "count": 1,
+            "messages": [{
+                "uid": "42",
+                "from_addr": "alice@example.com",
+                "from_name": "Alice",
+                "subject": "Hello",
+                "date": "Mon, 24 Mar 2026 10:00:00 -0400",
+                "unread": True,
+                "size": 1024,
+            }]
+        }
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_list(data)
+        output = captured.getvalue()
+        self.assertIn("alice@example.com", output)
+        self.assertIn("Hello", output)
+
+    def test_output_human_list_empty(self):
+        """Test human-readable list output with no messages."""
+        data = {"folder": "INBOX", "count": 0, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_list(data)
+        output = captured.getvalue()
+        self.assertIn("No messages", output)
+
+    def test_output_human_read(self):
+        """Test human-readable read output."""
+        data = {
+            "uid": "42",
+            "folder": "INBOX",
+            "from_addr": "alice@example.com",
+            "from_name": "Alice",
+            "subject": "Hello",
+            "date": "Mon, 24 Mar 2026",
+            "to": "bob@example.com",
+            "body_plain": "Hi Bob!",
+            "body_html": None,
+            "attachments": [],
+        }
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_read(data)
+        output = captured.getvalue()
+        self.assertIn("From: Alice <alice@example.com>", output)
+        self.assertIn("Hi Bob!", output)
+
+    def test_output_human_check_with_unread(self):
+        """Test human-readable check output with unread messages."""
+        data = {"folder": "INBOX", "unread_count": 3, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_check(data)
+        output = captured.getvalue()
+        self.assertIn("3", output)
+        self.assertIn("unread", output)
+
+    def test_output_human_check_none_unread(self):
+        """Test human-readable check output with no unread messages."""
+        data = {"folder": "INBOX", "unread_count": 0, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_check(data)
+        output = captured.getvalue()
+        self.assertIn("No unread", output)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_herd_mail.py::TestOutput -v`
+Expected: FAIL — `hm.output_json` not found
+
+- [ ] **Step 3: Implement output helpers**
+
+Add to `herd_mail.py` after `build_waggle_config` and before `main()`. Also add `import json` at the top of the file with the other imports:
+
+```python
+import json
+```
+
+Then add the output helpers:
+
+```python
+DEFAULT_LIST_LIMIT = 20
+
+
+def output_json(data: dict[str, Any]) -> None:
+    """Write JSON to stdout. All logging must go to stderr."""
+    print(json.dumps(data, indent=2, default=str))
+
+
+def output_human_list(data: dict[str, Any]) -> None:
+    """Write human-readable message list to stdout."""
+    messages = data.get("messages", [])
+    if not messages:
+        print(f"No messages in {data['folder']}.")
+        return
+
+    print(f"{'UID':<8} {'From':<30} {'Subject':<40} {'Date':<20} {'Status'}")
+    print("-" * 110)
+    for msg in messages:
+        status = "*" if msg.get("unread") else " "
+        from_display = msg.get("from_name") or msg.get("from_addr", "")
+        subject = msg.get("subject", "(no subject)")
+        # Truncate long fields
+        from_display = from_display[:28] if len(from_display) > 28 else from_display
+        subject = subject[:38] if len(subject) > 38 else subject
+        date = msg.get("date", "")[:18]
+        print(f"{msg['uid']:<8} {from_display:<30} {subject:<40} {date:<20} {status}")
+
+
+def output_human_read(data: dict[str, Any]) -> None:
+    """Write human-readable message to stdout."""
+    from_name = data.get("from_name", "")
+    from_addr = data.get("from_addr", "")
+    from_display = f"{from_name} <{from_addr}>" if from_name else from_addr
+
+    print(f"From: {from_display}")
+    print(f"To: {data.get('to', '')}")
+    print(f"Date: {data.get('date', '')}")
+    print(f"Subject: {data.get('subject', '')}")
+
+    attachments = data.get("attachments", [])
+    if attachments:
+        names = ", ".join(a.get("filename", "unknown") for a in attachments)
+        print(f"Attachments: {names}")
+
+    print("-" * 60)
+
+    body = data.get("body_plain") or data.get("body_html") or "(no body)"
+    print(body)
+
+
+def output_human_check(data: dict[str, Any]) -> None:
+    """Write human-readable check result to stdout."""
+    count = data.get("unread_count", 0)
+    folder = data.get("folder", "INBOX")
+    if count == 0:
+        print(f"No unread messages in {folder}.")
+    else:
+        print(f"{count} unread message(s) in {folder}.")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_herd_mail.py::TestOutput -v`
+Expected: 6 passed
+
+- [ ] **Step 5: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: 39 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Add output helpers for JSON and human-readable formatting"
+```
+
+---
+
+### Task 4: Refactor main() to subcommand dispatch with cmd_send and cmd_config
+
+This is the biggest structural change. Extract the existing send logic into `cmd_send`, dry-run into `cmd_config`, and replace `main()` with subcommand dispatch.
+
+**Files:**
+- Modify: `herd_mail.py:399-601` (replace main() entirely)
+- Modify: `test_herd_mail.py` (update TestMain argv, add TestCmdConfig, TestBackwardCompat)
+
+- [ ] **Step 1: Write tests for subcommand dispatch, config, and backward compat**
+
+Add to `test_herd_mail.py`:
+
+```python
+class TestCmdConfig(unittest.TestCase):
+    """Test config subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    def test_config_valid(self):
+        """Test config command with valid SMTP+IMAP config."""
+        with patch('sys.argv', ['herd_mail.py', 'config']):
+            result = hm.main()
+        self.assertEqual(result, 0)
+
+    def test_config_missing_imap(self):
+        """Test config command warns about missing IMAP."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'config']):
+            result = hm.main()
+        # config still succeeds if SMTP is valid, but warns about IMAP
+        self.assertEqual(result, 0)
+
+
+class TestBackwardCompat(unittest.TestCase):
+    """Test backward compatibility for old-style invocations."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.send_email')
+    @patch('herd_mail.check_recently_sent')
+    def test_old_style_send(self, mock_check, mock_send):
+        """Test old-style --to without subcommand still works."""
+        mock_check.return_value = False
+        mock_send.return_value = None
+
+        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+                                '--subject', 'Hello', '--body', 'Hi!']):
+            result = hm.main()
+
+        self.assertEqual(result, 0)
+        mock_send.assert_called_once()
+
+    def test_no_args_shows_help(self):
+        """Test no arguments exits with error (help shown)."""
+        with patch('sys.argv', ['herd_mail.py']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+```
+
+- [ ] **Step 2: Update existing TestMain tests to use subcommand argv**
+
+In `test_herd_mail.py`, update all `TestMain` test methods. Replace every occurrence of `['herd_mail.py', '--to'` with `['herd_mail.py', 'send', '--to'` and `['herd_mail.py', '--dry-run'` with `['herd_mail.py', 'send', '--dry-run'`. Specifically:
+
+In `test_send_simple_email`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'Hi there!']`
+
+In `test_duplicate_detection`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'Hi!']`
+
+In `test_skip_duplicate_check`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'Hi!', '--skip-duplicate-check']`
+
+In `test_dry_run`: change argv to `['herd_mail.py', 'send', '--dry-run', '--to', 'test@example.com', '--subject', 'Test']`
+
+In `test_missing_config`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'Hi!']`
+
+In `test_invalid_email_address`: change argv to `['herd_mail.py', 'send', '--to', 'not_an_email', '--subject', 'Hello', '--body', 'Hi!']`
+
+In `test_invalid_cc_address`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'Hi!', '--cc', 'invalid_email']`
+
+In `test_with_attachments`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'See attached', '--attachment', 'file1.pdf', 'file2.txt']`
+
+In `test_escape_sequences_in_body`: change argv to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body', 'Line1\\nLine2']`
+
+Update `TestBodyLoading` similarly:
+
+In `test_body_from_file`: change to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body-file', temp_path]`
+
+In `test_body_from_stdin`: change to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello']`
+
+In `test_body_file_not_found`: change to `['herd_mail.py', 'send', '--to', 'friend@example.com', '--subject', 'Hello', '--body-file', '/tmp/nonexistent_file_12345.txt']`
+
+- [ ] **Step 3: Run tests to see failures**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: Many failures — `main()` doesn't understand subcommands yet
+
+- [ ] **Step 4: Rewrite main() with subcommand dispatch, cmd_send, cmd_config**
+
+Replace everything from `def main()` to the end of the file in `herd_mail.py` with:
+
+```python
+def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the send subcommand."""
+    # Validate email addresses early
+    if not validate_email_address(args.to):
+        logger.error(f"Invalid recipient email address: {sanitize_for_display(args.to)}")
+        return 1
+
+    if args.cc and not validate_email_list(args.cc):
+        logger.error(f"Invalid CC email address(es): {sanitize_for_display(args.cc)}")
+        return 1
+
+    if args.reply_to and not validate_email_address(args.reply_to):
+        logger.error(f"Invalid Reply-To email address: {sanitize_for_display(args.reply_to)}")
+        return 1
+
+    # Handle --dry-run as alias for config command
+    if args.dry_run:
+        return cmd_config(args, cfg)
+
+    # Validate SMTP configuration
+    if not validate_config(cfg, require_smtp=True):
+        return 1
+
+    # Get body content
+    body: Optional[str] = None
+    if args.body_file:
+        validated_path = validate_file_path(args.body_file, must_exist=True)
+        if not validated_path:
+            return 1
+
+        try:
+            with open(validated_path, "r", encoding="utf-8") as f:
+                body = f.read()
+        except UnicodeDecodeError as e:
+            logger.error(f"Error: Body file must be UTF-8: {e}")
+            return 1
+        except OSError as e:
+            logger.error(f"Error reading body file: {e}")
+            return 1
+    elif args.body:
+        body = decode_escape_sequences(args.body)
+    else:
+        if not sys.stdin.isatty():
+            try:
+                body = sys.stdin.read()
+            except (OSError, UnicodeDecodeError) as e:
+                logger.error(f"Error reading from stdin: {e}")
+                return 1
+        else:
+            body = DEFAULT_NO_BODY_MESSAGE
+
+    # Check for duplicates (unless skipped)
+    if not args.skip_duplicate_check:
+        try:
+            if check_recently_sent(
+                args.to,
+                args.subject,
+                within_minutes=DEFAULT_DUPLICATE_CHECK_MINUTES,
+                config=build_waggle_config(cfg)
+            ):
+                logger.warning(
+                    f"Duplicate detected: recently sent to "
+                    f"{sanitize_for_display(args.to)} with similar subject"
+                )
+                logger.info("Use --skip-duplicate-check to override")
+                return 0
+        except (OSError, ValueError) as e:
+            logger.warning(f"Could not check for duplicates: {e}")
+            logger.info("Continuing anyway...")
+
+    # Handle reply with threading
+    in_reply_to: Optional[str] = None
+    references: Optional[str] = None
+
+    if args.message_id:
+        try:
+            logger.info(f"Fetching original message {args.message_id} for threading...")
+            original = read_message(
+                args.message_id,
+                folder=DEFAULT_IMAP_FOLDER,
+                config=build_waggle_config(cfg)
+            )
+            in_reply_to = original.get("message_id")
+            references = original.get("reply_references")
+            subject = sanitize_for_display(original.get('subject', 'Unknown'))
+            logger.info(f"  Found: {subject}")
+        except (ConnectionError, TimeoutError, OSError) as e:
+            logger.warning(f"Warning: Could not fetch original message: {e}")
+            logger.info("  Continuing without threading headers...")
+        except Exception as e:
+            logger.warning(f"Unexpected error fetching message: {e}")
+            logger.info("  Continuing without threading headers...")
+
+    # Send the email
+    try:
+        to_display = sanitize_for_display(args.to, max_length=50)
+        logger.info(f"Sending email to {to_display}...")
+
+        send_email(
+            to=args.to,
+            subject=args.subject,
+            body_md=body,
+            cc=args.cc,
+            reply_to=args.reply_to,
+            in_reply_to=in_reply_to,
+            references=references,
+            attachments=args.attachment,
+            rich=args.rich,
+            config=build_waggle_config(cfg),
+        )
+
+        logger.info("Email sent successfully!")
+        if cfg.get("imap_host"):
+            logger.info("  (Saved to Sent folder via IMAP)")
+
+        return 0
+
+    except ConnectionError as e:
+        logger.error(f"Connection error: {e}")
+        return 1
+    except TimeoutError as e:
+        logger.error(f"Timeout error: {e}")
+        return 1
+    except ValueError as e:
+        logger.error(f"Invalid input: {e}")
+        return 1
+    except OSError as e:
+        logger.error(f"I/O error: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        logger.debug("", exc_info=True)
+        return 1
+
+
+def cmd_config(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the config subcommand. Validates SMTP and IMAP settings."""
+    smtp_valid = validate_config(cfg, require_smtp=True, require_imap=False)
+
+    if smtp_valid:
+        logger.info("SMTP configuration valid.")
+        smtp_user_display = cfg['smtp_user'][:3] + "***" if cfg['smtp_user'] else "***"
+        logger.info(f"  SMTP: {smtp_user_display}@{cfg['smtp_host']}:{cfg['smtp_port']}")
+        logger.info(f"  From: {cfg['from_name']} <{cfg['from_addr']}>")
+    else:
+        logger.error("SMTP configuration invalid.")
+
+    if cfg.get("imap_host"):
+        logger.info(f"  IMAP: {cfg['imap_host']}:{cfg['imap_port']} (configured)")
+    else:
+        logger.warning("  IMAP: not configured (set WAGGLE_IMAP_HOST for read commands)")
+
+    return 0 if smtp_valid else 1
+
+
+def main() -> int:
+    """Main entry point with subcommand dispatch."""
+    if not WAGGLE_AVAILABLE:
+        logger.error("Error: waggle not installed. Run: pip install waggle-mail")
+        if WAGGLE_IMPORT_ERROR:
+            logger.error(f"Details: {WAGGLE_IMPORT_ERROR}")
+        return 1
+
+    # Backward compat: detect old-style invocation (no subcommand, but --to present)
+    if len(sys.argv) > 1 and sys.argv[1].startswith('--'):
+        if '--to' in sys.argv:
+            logger.warning("Deprecation warning: use 'herd_mail.py send --to ...' instead")
+            sys.argv.insert(1, 'send')
+        elif '--dry-run' in sys.argv:
+            logger.warning("Deprecation warning: use 'herd_mail.py config' instead")
+            # Rewrite to: send --dry-run (which dispatches to cmd_config internally)
+            sys.argv.insert(1, 'send')
+
+    parser = argparse.ArgumentParser(
+        description="herd-mail: AI-to-AI email communication via waggle",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # send subcommand
+    send_parser = subparsers.add_parser("send", help="Send an email")
+    send_parser.add_argument("--to", required=True, help="Recipient email address")
+    send_parser.add_argument("--subject", required=True, help="Email subject line")
+    send_parser.add_argument("--body", help="Email body (Markdown supported)")
+    send_parser.add_argument("--body-file", help="Read body from file (UTF-8)")
+    send_parser.add_argument("--attachment", nargs="+", help="File(s) to attach")
+    send_parser.add_argument("--cc", help="CC recipients (comma-separated)")
+    send_parser.add_argument("--reply-to", help="Reply-To address")
+    send_parser.add_argument("--message-id", help="IMAP message ID to reply to (enables threading)")
+    send_parser.add_argument("--rich", action="store_true", help="Enable rich HTML formatting")
+    send_parser.add_argument("--skip-duplicate-check", action="store_true", help="Skip duplicate detection")
+    send_parser.add_argument("--dry-run", action="store_true", help="Validate config without sending")
+
+    # list subcommand
+    list_parser = subparsers.add_parser("list", help="List messages in a folder")
+    list_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    list_parser.add_argument("--limit", type=int, default=DEFAULT_LIST_LIMIT, help="Max messages (default: 20)")
+    list_parser.add_argument("--unread", action="store_true", help="Only show unread messages")
+    list_parser.add_argument("--human", action="store_true", help="Human-readable output")
+
+    # read subcommand
+    read_parser = subparsers.add_parser("read", help="Read a full message by UID")
+    read_parser.add_argument("uid", help="IMAP message UID")
+    read_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    read_parser.add_argument("--human", action="store_true", help="Human-readable output")
+
+    # check subcommand
+    check_parser = subparsers.add_parser("check", help="Check for unread messages")
+    check_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    check_parser.add_argument("--human", action="store_true", help="Human-readable output")
+
+    # download subcommand
+    dl_parser = subparsers.add_parser("download", help="Download attachments from a message")
+    dl_parser.add_argument("uid", help="IMAP message UID")
+    dl_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    dl_parser.add_argument("--dest-dir", default=".", help="Destination directory (default: .)")
+
+    # config subcommand
+    subparsers.add_parser("config", help="Validate configuration")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Load configuration
+    try:
+        cfg = get_config()
+    except ValueError as e:
+        logger.error(f"Configuration error: {e}")
+        return 1
+
+    # Dispatch to command handler
+    commands = {
+        "send": cmd_send,
+        "config": cmd_config,
+    }
+
+    handler = commands.get(args.command)
+    if handler:
+        return handler(args, cfg)
+
+    # Placeholder for read-side commands (implemented in later tasks)
+    logger.error(f"Command '{args.command}' not yet implemented")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All tests pass (~43 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Refactor main() to subcommand dispatch with cmd_send and cmd_config"
+```
+
+---
+
+### Task 5: Implement cmd_list
+
+**Files:**
+- Modify: `herd_mail.py` — add `cmd_list` function, wire into dispatch
+- Modify: `test_herd_mail.py` — add TestCmdList class
+
+- [ ] **Step 1: Write tests for cmd_list**
+
+Add to `test_herd_mail.py`:
+
+```python
+class TestCmdList(unittest.TestCase):
+    """Test list subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.list_inbox')
+    def test_list_json_output(self, mock_list):
+        """Test list outputs JSON to stdout."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "alice@example.com", "from_name": "Alice",
+             "subject": "Hello", "date": "Mon, 24 Mar 2026", "flags": "",
+             "unread": True, "size": 1024},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["messages"][0]["from_addr"], "alice@example.com")
+
+    @patch('herd_mail.list_inbox')
+    def test_list_unread_filter(self, mock_list):
+        """Test --unread filters to unread only."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "a@example.com", "from_name": "A",
+             "subject": "Read", "date": "Mon", "flags": "\\Seen",
+             "unread": False, "size": 100},
+            {"uid": "2", "from_addr": "b@example.com", "from_name": "B",
+             "subject": "Unread", "date": "Tue", "flags": "",
+             "unread": True, "size": 200},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list', '--unread']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["messages"][0]["uid"], "2")
+
+    @patch('herd_mail.list_inbox')
+    def test_list_empty(self, mock_list):
+        """Test list with empty inbox."""
+        mock_list.return_value = []
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["count"], 0)
+
+    @patch('herd_mail.list_inbox')
+    def test_list_human_output(self, mock_list):
+        """Test list with --human flag."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "alice@example.com", "from_name": "Alice",
+             "subject": "Hello", "date": "Mon, 24 Mar 2026", "flags": "",
+             "unread": True, "size": 1024},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list', '--human']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("alice@example.com", output)
+
+    def test_list_no_imap(self):
+        """Test list fails without IMAP config."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'list']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+```
+
+- [ ] **Step 2: Run tests to see failures**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdList -v`
+Expected: FAIL — `list` command not yet implemented
+
+- [ ] **Step 3: Implement cmd_list**
+
+Add to `herd_mail.py` after `cmd_config`:
+
+```python
+def cmd_list(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the list subcommand."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    try:
+        messages = list_inbox(
+            folder=args.folder,
+            limit=args.limit,
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to list messages: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error listing messages: {e}")
+        return 1
+
+    if args.unread:
+        messages = [m for m in messages if m.get("unread")]
+
+    data = {
+        "folder": args.folder,
+        "count": len(messages),
+        "messages": messages,
+    }
+
+    if args.human:
+        output_human_list(data)
+    else:
+        output_json(data)
+
+    return 0
+```
+
+Update the dispatch dict in `main()`:
+
+```python
+    commands = {
+        "send": cmd_send,
+        "list": cmd_list,
+        "config": cmd_config,
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdList -v`
+Expected: 5 passed
+
+- [ ] **Step 5: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All pass (~48 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Implement list subcommand with JSON/human output and unread filter"
+```
+
+---
+
+### Task 6: Implement cmd_read
+
+**Files:**
+- Modify: `herd_mail.py` — add `cmd_read`, wire into dispatch
+- Modify: `test_herd_mail.py` — add TestCmdRead class
+
+- [ ] **Step 1: Write tests for cmd_read**
+
+Add to `test_herd_mail.py`:
+
+```python
+class TestCmdRead(unittest.TestCase):
+    """Test read subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.read_message')
+    def test_read_json_output(self, mock_read):
+        """Test read outputs full message as JSON."""
+        mock_read.return_value = {
+            "uid": "42", "folder": "INBOX",
+            "message_id": "<abc@example.com>",
+            "from_addr": "alice@example.com", "from_name": "Alice",
+            "subject": "Hello", "date": "Mon, 24 Mar 2026",
+            "to": "bob@example.com",
+            "body_plain": "Hi Bob!", "body_html": None,
+            "in_reply_to": None, "references": None,
+            "attachments": [],
+        }
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'read', '42']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["uid"], "42")
+        self.assertEqual(data["body_plain"], "Hi Bob!")
+
+    @patch('herd_mail.read_message')
+    def test_read_human_output(self, mock_read):
+        """Test read with --human flag."""
+        mock_read.return_value = {
+            "uid": "42", "folder": "INBOX",
+            "from_addr": "alice@example.com", "from_name": "Alice",
+            "subject": "Hello", "date": "Mon, 24 Mar 2026",
+            "to": "bob@example.com",
+            "body_plain": "Hi Bob!", "body_html": None,
+            "attachments": [],
+        }
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'read', '42', '--human']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("From: Alice <alice@example.com>", output)
+        self.assertIn("Hi Bob!", output)
+
+    @patch('herd_mail.read_message')
+    def test_read_connection_error(self, mock_read):
+        """Test read handles connection errors."""
+        mock_read.side_effect = ConnectionError("Connection refused")
+        with patch('sys.argv', ['herd_mail.py', 'read', '99']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+    def test_read_no_imap(self):
+        """Test read fails without IMAP config."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'read', '42']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+```
+
+- [ ] **Step 2: Run tests to see failures**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdRead -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement cmd_read**
+
+Add to `herd_mail.py` after `cmd_list`:
+
+```python
+def cmd_read(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the read subcommand."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    try:
+        message = read_message(
+            args.uid,
+            folder=args.folder,
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to read message {args.uid}: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error reading message: {e}")
+        return 1
+
+    if args.human:
+        output_human_read(message)
+    else:
+        output_json(message)
+
+    return 0
+```
+
+Update dispatch dict in `main()`:
+
+```python
+    commands = {
+        "send": cmd_send,
+        "list": cmd_list,
+        "read": cmd_read,
+        "config": cmd_config,
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdRead -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All pass (~52 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Implement read subcommand for full message retrieval"
+```
+
+---
+
+### Task 7: Implement cmd_check
+
+**Files:**
+- Modify: `herd_mail.py` — add `cmd_check`, wire into dispatch
+- Modify: `test_herd_mail.py` — add TestCmdCheck class
+
+- [ ] **Step 1: Write tests for cmd_check**
+
+Add to `test_herd_mail.py`:
+
+```python
+class TestCmdCheck(unittest.TestCase):
+    """Test check subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.list_inbox')
+    def test_check_has_unread(self, mock_list):
+        """Test check returns 0 when unread messages exist."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "a@example.com", "from_name": "A",
+             "subject": "New", "date": "Mon", "flags": "",
+             "unread": True, "size": 100},
+            {"uid": "2", "from_addr": "b@example.com", "from_name": "B",
+             "subject": "Read", "date": "Tue", "flags": "\\Seen",
+             "unread": False, "size": 200},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'check']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["unread_count"], 1)
+
+    @patch('herd_mail.list_inbox')
+    def test_check_no_unread(self, mock_list):
+        """Test check returns 1 when no unread messages."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "a@example.com", "from_name": "A",
+             "subject": "Read", "date": "Mon", "flags": "\\Seen",
+             "unread": False, "size": 100},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'check']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 1)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["unread_count"], 0)
+
+    @patch('herd_mail.list_inbox')
+    def test_check_connection_error(self, mock_list):
+        """Test check returns 2 on error."""
+        mock_list.side_effect = ConnectionError("Connection refused")
+        with patch('sys.argv', ['herd_mail.py', 'check']):
+            result = hm.main()
+        self.assertEqual(result, 2)
+
+    @patch('herd_mail.list_inbox')
+    def test_check_human_output(self, mock_list):
+        """Test check with --human flag."""
+        mock_list.return_value = [
+            {"uid": "1", "unread": True, "from_addr": "a@example.com",
+             "from_name": "A", "subject": "New", "date": "Mon",
+             "flags": "", "size": 100},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'check', '--human']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("1", output)
+        self.assertIn("unread", output)
+```
+
+- [ ] **Step 2: Run tests to see failures**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdCheck -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement cmd_check**
+
+Add to `herd_mail.py` after `cmd_read`:
+
+```python
+def cmd_check(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """
+    Handle the check subcommand.
+
+    Exit codes: 0=has unread, 1=no unread, 2=error.
+    """
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 2
+
+    try:
+        messages = list_inbox(
+            folder=args.folder,
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to check messages: {e}")
+        return 2
+    except Exception as e:
+        logger.error(f"Unexpected error checking messages: {e}")
+        return 2
+
+    unread = [m for m in messages if m.get("unread")]
+
+    data = {
+        "folder": args.folder,
+        "unread_count": len(unread),
+        "messages": unread,
+    }
+
+    if args.human:
+        output_human_check(data)
+    else:
+        output_json(data)
+
+    return 0 if unread else 1
+```
+
+Update dispatch dict in `main()`:
+
+```python
+    commands = {
+        "send": cmd_send,
+        "list": cmd_list,
+        "read": cmd_read,
+        "check": cmd_check,
+        "config": cmd_config,
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdCheck -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All pass (~56 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Implement check subcommand with exit code semantics for polling"
+```
+
+---
+
+### Task 8: Implement cmd_download
+
+**Files:**
+- Modify: `herd_mail.py` — add `cmd_download`, wire into dispatch
+- Modify: `test_herd_mail.py` — add TestCmdDownload class
+
+- [ ] **Step 1: Write tests for cmd_download**
+
+Add to `test_herd_mail.py`:
+
+```python
+class TestCmdDownload(unittest.TestCase):
+    """Test download subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.download_attachments')
+    def test_download_files(self, mock_dl):
+        """Test download returns file paths as JSON."""
+        mock_dl.return_value = ["/tmp/report.pdf", "/tmp/data.csv"]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["uid"], "42")
+        self.assertEqual(len(data["files"]), 2)
+
+    @patch('herd_mail.download_attachments')
+    def test_download_no_attachments(self, mock_dl):
+        """Test download with no attachments returns empty list."""
+        mock_dl.return_value = []
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["files"], [])
+
+    @patch('herd_mail.download_attachments')
+    def test_download_with_dest_dir(self, mock_dl):
+        """Test download with --dest-dir."""
+        mock_dl.return_value = ["/custom/dir/file.pdf"]
+        captured = StringIO()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('sys.argv', ['herd_mail.py', 'download', '42', '--dest-dir', tmpdir]):
+                with patch('sys.stdout', captured):
+                    result = hm.main()
+        self.assertEqual(result, 0)
+        mock_dl.assert_called_once()
+        call_kwargs = mock_dl.call_args[1] if mock_dl.call_args[1] else {}
+        call_args = mock_dl.call_args[0] if mock_dl.call_args[0] else ()
+        # Verify dest_dir was passed (positional or keyword)
+        self.assertTrue(tmpdir in str(mock_dl.call_args))
+
+    @patch('herd_mail.download_attachments')
+    def test_download_connection_error(self, mock_dl):
+        """Test download handles connection errors."""
+        mock_dl.side_effect = ConnectionError("Connection refused")
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+    def test_download_no_imap(self):
+        """Test download fails without IMAP config."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+```
+
+- [ ] **Step 2: Run tests to see failures**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdDownload -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement cmd_download**
+
+Add to `herd_mail.py` after `cmd_check`:
+
+```python
+def cmd_download(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the download subcommand."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    # Ensure dest_dir exists
+    dest_dir = Path(args.dest_dir)
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.error(f"Cannot create destination directory: {e}")
+        return 1
+
+    try:
+        files = download_attachments(
+            args.uid,
+            folder=args.folder,
+            dest_dir=str(dest_dir),
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to download attachments: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error downloading attachments: {e}")
+        return 1
+
+    data = {
+        "uid": args.uid,
+        "folder": args.folder,
+        "files": files,
+    }
+
+    output_json(data)
+    return 0
+```
+
+Update dispatch dict in `main()`:
+
+```python
+    commands = {
+        "send": cmd_send,
+        "list": cmd_list,
+        "read": cmd_read,
+        "check": cmd_check,
+        "download": cmd_download,
+        "config": cmd_config,
+    }
+```
+
+Also remove the placeholder at the bottom of `main()`:
+
+```python
+    # Remove these lines:
+    # logger.error(f"Command '{args.command}' not yet implemented")
+    # return 1
+```
+
+Replace with:
+
+```python
+    logger.error(f"Unknown command: {args.command}")
+    return 1
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest test_herd_mail.py::TestCmdDownload -v`
+Expected: 5 passed
+
+- [ ] **Step 5: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All pass (~61 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Implement download subcommand for attachment retrieval"
+```
+
+---
+
+### Task 9: Update module docstring and run_basic_tests
+
+**Files:**
+- Modify: `herd_mail.py:1-48` (module docstring)
+- Modify: `test_herd_mail.py` (run_basic_tests function)
+
+- [ ] **Step 1: Update module docstring**
+
+Replace the module docstring at the top of `herd_mail.py` (lines 2-48) with:
+
+```python
+"""
+herd-mail: AI-to-AI communication facilitator for the herd.
+
+A secure, user-friendly wrapper for waggle that handles the full lifecycle
+of herd email communication: sending, reading, checking, and downloading.
+
+Commands:
+    herd_mail.py send --to recipient@example.com --subject "Hello" --body "Message"
+    herd_mail.py list [--folder INBOX] [--limit 20] [--unread] [--human]
+    herd_mail.py read <uid> [--folder INBOX] [--human]
+    herd_mail.py check [--folder INBOX] [--human]
+    herd_mail.py download <uid> [--folder INBOX] [--dest-dir .]
+    herd_mail.py config
+
+Environment Variables (see .envrc.template):
+    WAGGLE_HOST         SMTP host
+    WAGGLE_PORT         SMTP port (default: 465)
+    WAGGLE_USER         SMTP/IMAP username
+    WAGGLE_PASS         SMTP/IMAP password
+    WAGGLE_FROM         From email address
+    WAGGLE_NAME         Display name
+    WAGGLE_TLS          Use TLS (default: true)
+    WAGGLE_IMAP_HOST    IMAP host (required for list/read/check/download)
+    WAGGLE_IMAP_PORT    IMAP port (default: 993)
+    WAGGLE_IMAP_TLS     Use IMAP TLS (default: true)
+    WAGGLE_TO           Default test recipient
+    WAGGLE_SEND_LOG     Path to send log (for duplicate detection)
+    WAGGLE_DEV_PATH     Optional: Path to local waggle for development
+
+Author: O.C.
+License: MIT
+"""
+```
+
+- [ ] **Step 2: Update run_basic_tests in test_herd_mail.py**
+
+Replace the `run_basic_tests` function with:
+
+```python
+def run_basic_tests():
+    """Run basic tests without pytest."""
+    print("Running basic validation tests...")
+    print("=" * 60)
+
+    print("\n1. Testing email validation...")
+    assert hm.validate_email_address("user@example.com") == True
+    assert hm.validate_email_address("invalid") == False
+    assert hm.validate_email_address("user\n@example.com") == False
+    print("   Pass")
+
+    print("\n2. Testing port parsing...")
+    assert hm.parse_port("465", 0, "test") == 465
+    try:
+        hm.parse_port("invalid", 0, "test")
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass
+    print("   Pass")
+
+    print("\n3. Testing escape sequences...")
+    assert hm.decode_escape_sequences("hello\\nworld") == "hello\nworld"
+    assert hm.decode_escape_sequences("hello\\\\world") == "hello\\world"
+    print("   Pass")
+
+    print("\n4. Testing sanitization...")
+    assert hm.sanitize_for_display("hello\x1b[31mworld") == "helloworld"
+    assert hm.sanitize_for_display("hello\nworld") == "hello\nworld"
+    print("   Pass")
+
+    print("\n5. Testing config loading...")
+    os.environ["WAGGLE_HOST"] = "smtp.example.com"
+    os.environ["WAGGLE_USER"] = "user@example.com"
+    os.environ["WAGGLE_PASS"] = "secret"
+    os.environ["WAGGLE_FROM"] = "user@example.com"
+
+    cfg = hm.get_config()
+    assert cfg["smtp_host"] == "smtp.example.com"
+    assert cfg["smtp_port"] == 465
+    print("   Pass")
+
+    print("\n6. Testing IMAP validation...")
+    assert hm.validate_config(cfg, require_smtp=False, require_imap=True) == False
+    cfg["imap_host"] = "imap.example.com"
+    assert hm.validate_config(cfg, require_smtp=False, require_imap=True) == True
+    print("   Pass")
+
+    print("\n7. Testing output helpers...")
+    import json
+    from io import StringIO
+    data = {"folder": "INBOX", "count": 0, "messages": []}
+    captured = StringIO()
+    import sys as _sys
+    old_stdout = _sys.stdout
+    _sys.stdout = captured
+    hm.output_json(data)
+    _sys.stdout = old_stdout
+    assert json.loads(captured.getvalue())["count"] == 0
+    print("   Pass")
+
+    print("\n" + "=" * 60)
+    print("All basic tests passed!")
+    print("\nFor full test suite: python3 -m pytest test_herd_mail.py -v")
+```
+
+- [ ] **Step 3: Run full suite**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All pass (~61 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add herd_mail.py test_herd_mail.py
+git commit -m "Update docstring for subcommand usage and refresh basic tests"
+```
+
+---
+
+### Task 10: Update CLAUDE.md and README.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+Update the Development Commands and Architecture sections to reflect the new subcommand structure. Key changes:
+
+- Add list/read/check/download examples to "Running the script" section
+- Update Architecture section to describe subcommand dispatch
+- Add note about JSON output for AI agents
+- Update the Core Flow section to include read-side flow
+
+- [ ] **Step 2: Update README.md**
+
+Key changes to README.md:
+
+- Update Quick Start with new subcommand syntax
+- Add "Reading Mail" section with list/read/check/download examples
+- Update Command Line Reference with all subcommands
+- Update the "How It Works" section
+- Note the backward compatibility for old-style send invocations
+
+- [ ] **Step 3: Run tests one final time**
+
+Run: `python3 -m pytest test_herd_mail.py -v`
+Expected: All pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "Update documentation for subcommand CLI structure"
+```

--- a/docs/superpowers/specs/2026-03-26-subcommand-refactor-design.md
+++ b/docs/superpowers/specs/2026-03-26-subcommand-refactor-design.md
@@ -1,0 +1,243 @@
+# herd-mail Subcommand Refactor — Read/Check/Download Support
+
+**Date:** 2026-03-26
+**Status:** Approved
+
+## Problem
+
+herd_mail.py currently only sends email. AI agents in the herd also need to check their inbox, read messages, and download attachments. The underlying waggle library already supports these operations (`list_inbox`, `read_message`, `download_attachments`) but herd-mail doesn't expose them.
+
+## Design
+
+### CLI Structure
+
+Refactor from flat flags to subcommands:
+
+```
+herd_mail.py <command> [options]
+
+Commands:
+  send       Send an email
+  list       List messages in a folder
+  read       Read a full message by UID
+  check      Check for unread messages (exit code semantics)
+  download   Download attachments from a message
+  config     Validate configuration
+```
+
+Backward compatibility: if no subcommand is given but `--to` is present, dispatch to `send` with a deprecation warning logged to stderr.
+
+### Subcommand Specifications
+
+#### `send`
+
+Unchanged from current behavior. All existing flags preserved.
+
+```
+herd_mail.py send --to TO --subject SUBJECT [--body BODY] [--body-file FILE]
+    [--attachment FILE ...] [--cc CC] [--reply-to ADDR]
+    [--message-id UID] [--rich] [--skip-duplicate-check]
+```
+
+Exit codes: 0=sent, 1=error.
+
+#### `list`
+
+```
+herd_mail.py list [--folder FOLDER] [--limit N] [--unread] [--human]
+```
+
+- `--folder`: IMAP folder (default: `INBOX`)
+- `--limit`: Max messages to return (default: 20)
+- `--unread`: Only show unread messages
+- `--human`: Human-readable table instead of JSON
+
+Exit codes: 0=success, 1=error.
+
+JSON output:
+```json
+{
+  "folder": "INBOX",
+  "count": 2,
+  "messages": [
+    {
+      "uid": "145",
+      "from_addr": "alice@example.com",
+      "from_name": "Alice",
+      "subject": "Weekly sync",
+      "date": "Mon, 24 Mar 2026 10:00:00 -0400",
+      "unread": true,
+      "size": 4096
+    }
+  ]
+}
+```
+
+#### `read`
+
+```
+herd_mail.py read <uid> [--folder FOLDER] [--human]
+```
+
+Exit codes: 0=found, 1=error.
+
+JSON output:
+```json
+{
+  "uid": "145",
+  "folder": "INBOX",
+  "message_id": "<abc123@example.com>",
+  "from_addr": "alice@example.com",
+  "from_name": "Alice",
+  "subject": "Weekly sync",
+  "date": "Mon, 24 Mar 2026 10:00:00 -0400",
+  "to": "herd@example.com",
+  "body_plain": "Hey, here's the update...",
+  "body_html": "<html>...",
+  "in_reply_to": null,
+  "references": null,
+  "attachments": [
+    {"filename": "report.pdf", "content_type": "application/pdf", "size": 12345}
+  ]
+}
+```
+
+#### `check`
+
+```
+herd_mail.py check [--folder FOLDER] [--human]
+```
+
+Designed for polling loops: `if herd_mail.py check; then herd_mail.py list --unread; fi`
+
+Exit codes: 0=has unread messages, 1=no unread messages, 2=error.
+
+JSON output:
+```json
+{
+  "folder": "INBOX",
+  "unread_count": 3,
+  "messages": [...]
+}
+```
+
+#### `download`
+
+```
+herd_mail.py download <uid> [--folder FOLDER] [--dest-dir DIR]
+```
+
+- `--dest-dir`: Where to save files (default: `.`, created if needed)
+
+Exit codes: 0=downloaded (or no attachments), 1=error.
+
+JSON output:
+```json
+{
+  "uid": "145",
+  "folder": "INBOX",
+  "files": ["/absolute/path/report.pdf", "/absolute/path/data.csv"]
+}
+```
+
+#### `config`
+
+```
+herd_mail.py config
+```
+
+Validates both SMTP and IMAP configuration. The `--dry-run` flag on `send` is preserved as an alias for backward compatibility (dispatches to `cmd_config` internally).
+
+Exit codes: 0=valid, 1=invalid.
+
+### Output Format Rules
+
+- **JSON mode (default for list/read/check/download):** Only the JSON object goes to stdout. All logging goes to stderr. This lets agents pipe stdout directly to a JSON parser.
+- **Human mode (`--human`):** Formatted text to stdout. `list` shows a table, `read` shows headers then body, `check` shows a one-line summary, `download` shows file paths.
+- **`send` and `config`:** Keep current behavior (human output to stdout, no JSON mode needed).
+
+### Code Organization
+
+Single file, structured as:
+
+```
+herd_mail.py
+  Constants, logging, imports
+  Validation helpers (existing, unchanged)
+  Config helpers (existing; validate_config gets require_imap param)
+  Output helpers (new)
+    output_json(data)
+    output_human_list(data)
+    output_human_read(data)
+    output_human_check(data)
+  Command handlers
+    cmd_send(args, cfg)       — extracted from current main()
+    cmd_list(args, cfg)       — new
+    cmd_read(args, cfg)       — new
+    cmd_check(args, cfg)      — new
+    cmd_download(args, cfg)   — new
+    cmd_config(args, cfg)     — extracted from dry-run logic
+  main()                      — argparse subcommand setup, config loading, dispatch
+  Backward compat             — no subcommand + --to → cmd_send + deprecation warning
+```
+
+### New Waggle Imports
+
+```python
+from waggle import send_email, check_recently_sent, read_message, list_inbox, download_attachments
+```
+
+With corresponding stubs when waggle is not installed (for testing).
+
+### Config Validation
+
+Read-side commands require IMAP configuration. `validate_config` gains a `require_imap` parameter:
+
+```python
+def validate_config(cfg, require_smtp=True, require_imap=False) -> bool:
+```
+
+When `require_imap=True`, validates that `imap_host` is set. Commands that need IMAP (`list`, `read`, `check`, `download`) pass `require_imap=True`.
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| IMAP not configured | Exit 1 (or 2 for `check`): `"IMAP not configured. Set WAGGLE_IMAP_HOST"` |
+| Empty inbox / no unread | `list`: exit 0, empty array. `check`: exit 1, `unread_count: 0` |
+| Invalid UID | Exit 1, error to stderr |
+| Connection failure | Catch `ConnectionError`, `TimeoutError`, `OSError`. JSON error to stderr. |
+| No attachments on download | Exit 0, `files: []` |
+| dest-dir doesn't exist | Create it. If creation fails, exit 1. |
+
+### Backward Compatibility
+
+Detection in `main()`:
+
+```
+if no subcommand given:
+    if --to is present:
+        log deprecation warning to stderr
+        dispatch to cmd_send
+    else:
+        print help and exit
+```
+
+Existing invocations like `herd_mail.py --to alice@example.com --subject "Hi" --body "Hello"` continue to work with a warning.
+
+### Testing
+
+Same mock-waggle pattern as existing tests. New test classes:
+
+| Class | Tests | Coverage |
+|-------|-------|----------|
+| `TestCmdList` | 4-5 | JSON output, `--unread`, `--limit`, `--human`, empty inbox |
+| `TestCmdRead` | 3-4 | JSON output, `--human`, invalid UID, attachments |
+| `TestCmdCheck` | 3-4 | Exit 0 (unread), exit 1 (none), exit 2 (error), JSON |
+| `TestCmdDownload` | 3-4 | Saves files, `--dest-dir`, no attachments, invalid UID |
+| `TestCmdConfig` | 2 | Valid config, missing IMAP |
+| `TestBackwardCompat` | 2 | `--to` without subcommand, no args shows help |
+
+Existing `TestMain` tests updated to use `['herd_mail.py', 'send', ...]` argv.
+
+Target: ~45-50 tests total, up from 30.

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -88,7 +88,10 @@ WAGGLE_AVAILABLE = False
 WAGGLE_IMPORT_ERROR = None
 
 try:
-    from waggle import send_email, check_recently_sent, read_message
+    from waggle import (
+        send_email, check_recently_sent, read_message,
+        list_inbox, download_attachments,
+    )
     WAGGLE_AVAILABLE = True
 except ImportError as e:
     WAGGLE_IMPORT_ERROR = e
@@ -103,6 +106,12 @@ except ImportError as e:
         raise RuntimeError("waggle not installed")
 
     def read_message(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+
+    def list_inbox(*args, **kwargs):
+        raise RuntimeError("waggle not installed")
+
+    def download_attachments(*args, **kwargs):
         raise RuntimeError("waggle not installed")
 
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -723,6 +723,43 @@ def cmd_check(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     return 0 if unread else 1
 
 
+def cmd_download(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the download subcommand."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    # Ensure dest_dir exists
+    dest_dir = Path(args.dest_dir)
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.error(f"Cannot create destination directory: {e}")
+        return 1
+
+    try:
+        files = download_attachments(
+            args.uid,
+            folder=args.folder,
+            dest_dir=str(dest_dir),
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to download attachments: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error downloading attachments: {e}")
+        return 1
+
+    data = {
+        "uid": args.uid,
+        "folder": args.folder,
+        "files": files,
+    }
+
+    output_json(data)
+    return 0
+
+
 def main() -> int:
     """Main entry point with subcommand dispatch."""
     if not WAGGLE_AVAILABLE:
@@ -806,6 +843,7 @@ def main() -> int:
         "list": cmd_list,
         "read": cmd_read,
         "check": cmd_check,
+        "download": cmd_download,
         "config": cmd_config,
     }
 
@@ -813,8 +851,7 @@ def main() -> int:
     if handler:
         return handler(args, cfg)
 
-    # Placeholder for read-side commands (implemented in later tasks)
-    logger.error(f"Command '{args.command}' not yet implemented")
+    logger.error(f"Unknown command: {args.command}")
     return 1
 
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -456,6 +456,10 @@ def output_human_check(data: dict[str, Any]) -> None:
 
 def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     """Handle the send subcommand."""
+    # Handle --dry-run as alias for config command (before email validation)
+    if args.dry_run:
+        return cmd_config(args, cfg)
+
     # Validate email addresses early
     if not validate_email_address(args.to):
         logger.error(f"Invalid recipient email address: {sanitize_for_display(args.to)}")
@@ -468,10 +472,6 @@ def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     if args.reply_to and not validate_email_address(args.reply_to):
         logger.error(f"Invalid Reply-To email address: {sanitize_for_display(args.reply_to)}")
         return 1
-
-    # Handle --dry-run as alias for config command
-    if args.dry_run:
-        return cmd_config(args, cfg)
 
     # Validate SMTP configuration
     if not validate_config(cfg, require_smtp=True):
@@ -753,13 +753,15 @@ def main() -> int:
         return 1
 
     # Backward compat: detect old-style invocation (no subcommand, but --to present)
-    if len(sys.argv) > 1 and sys.argv[1].startswith('--'):
-        if '--to' in sys.argv:
+    # Work on a copy to avoid mutating the global sys.argv
+    argv = sys.argv[:]
+    if len(argv) > 1 and argv[1].startswith('--'):
+        if '--to' in argv:
             logger.warning("Deprecation warning: use 'herd_mail.py send --to ...' instead")
-            sys.argv.insert(1, 'send')
-        elif '--dry-run' in sys.argv:
+            argv.insert(1, 'send')
+        elif '--dry-run' in argv:
             logger.warning("Deprecation warning: use 'herd_mail.py config' instead")
-            sys.argv.insert(1, 'send')
+            argv.insert(1, 'send')
 
     parser = argparse.ArgumentParser(
         description="herd-mail: AI-to-AI email communication via waggle",
@@ -808,7 +810,7 @@ def main() -> int:
     # config subcommand
     subparsers.add_parser("config", help="Validate configuration")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv[1:])
 
     if not args.command:
         parser.print_help()

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -49,6 +49,7 @@ License: MIT
 """
 
 import argparse
+import json
 import logging
 import os
 import re
@@ -63,6 +64,7 @@ DEFAULT_IMAP_PORT = 993
 DEFAULT_DUPLICATE_CHECK_MINUTES = 5
 DEFAULT_IMAP_FOLDER = "INBOX"
 DEFAULT_NO_BODY_MESSAGE = "(No message body)"
+DEFAULT_LIST_LIMIT = 20
 
 # Logging setup
 logging.basicConfig(
@@ -407,6 +409,65 @@ def build_waggle_config(cfg: dict[str, Any]) -> dict[str, Any]:
         "imap_port": cfg.get("imap_port", DEFAULT_IMAP_PORT),
         "imap_tls": cfg.get("imap_tls", True),
     }
+
+
+def output_json(data: dict[str, Any]) -> None:
+    """Write JSON to stdout. All logging must go to stderr."""
+    print(json.dumps(data, indent=2, default=str))
+
+
+def output_human_list(data: dict[str, Any]) -> None:
+    """Write human-readable message list to stdout."""
+    messages = data.get("messages", [])
+    if not messages:
+        print(f"No messages in {data['folder']}.")
+        return
+
+    print(f"{'UID':<8} {'From':<30} {'Subject':<40} {'Date':<20} {'Status'}")
+    print("-" * 110)
+    for msg in messages:
+        status = "*" if msg.get("unread") else " "
+        from_name = msg.get("from_name", "")
+        from_addr = msg.get("from_addr", "")
+        # Show name if available, otherwise email; prefer showing the email for clarity
+        from_display = f"{from_name} ({from_addr})" if from_name and from_addr else (from_name or from_addr or "")
+        subject = msg.get("subject", "(no subject)")
+        from_display = from_display[:28] if len(from_display) > 28 else from_display
+        subject = subject[:38] if len(subject) > 38 else subject
+        date = msg.get("date", "")[:18]
+        print(f"{msg['uid']:<8} {from_display:<30} {subject:<40} {date:<20} {status}")
+
+
+def output_human_read(data: dict[str, Any]) -> None:
+    """Write human-readable message to stdout."""
+    from_name = data.get("from_name", "")
+    from_addr = data.get("from_addr", "")
+    from_display = f"{from_name} <{from_addr}>" if from_name else from_addr
+
+    print(f"From: {from_display}")
+    print(f"To: {data.get('to', '')}")
+    print(f"Date: {data.get('date', '')}")
+    print(f"Subject: {data.get('subject', '')}")
+
+    attachments = data.get("attachments", [])
+    if attachments:
+        names = ", ".join(a.get("filename", "unknown") for a in attachments)
+        print(f"Attachments: {names}")
+
+    print("-" * 60)
+
+    body = data.get("body_plain") or data.get("body_html") or "(no body)"
+    print(body)
+
+
+def output_human_check(data: dict[str, Any]) -> None:
+    """Write human-readable check result to stdout."""
+    count = data.get("unread_count", 0)
+    folder = data.get("folder", "INBOX")
+    if count == 0:
+        print(f"No unread messages in {folder}.")
+    else:
+        print(f"{count} unread message(s) in {folder}.")
 
 
 def main() -> int:

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -660,6 +660,32 @@ def cmd_list(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     return 0
 
 
+def cmd_read(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the read subcommand."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    try:
+        message = read_message(
+            args.uid,
+            folder=args.folder,
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to read message {args.uid}: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error reading message: {e}")
+        return 1
+
+    if args.human:
+        output_human_read(message)
+    else:
+        output_json(message)
+
+    return 0
+
+
 def main() -> int:
     """Main entry point with subcommand dispatch."""
     if not WAGGLE_AVAILABLE:
@@ -741,6 +767,7 @@ def main() -> int:
     commands = {
         "send": cmd_send,
         "list": cmd_list,
+        "read": cmd_read,
         "config": cmd_config,
     }
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -686,6 +686,43 @@ def cmd_read(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     return 0
 
 
+def cmd_check(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """
+    Handle the check subcommand.
+
+    Exit codes: 0=has unread, 1=no unread, 2=error.
+    """
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 2
+
+    try:
+        messages = list_inbox(
+            folder=args.folder,
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to check messages: {e}")
+        return 2
+    except Exception as e:
+        logger.error(f"Unexpected error checking messages: {e}")
+        return 2
+
+    unread = [m for m in messages if m.get("unread")]
+
+    data = {
+        "folder": args.folder,
+        "unread_count": len(unread),
+        "messages": unread,
+    }
+
+    if args.human:
+        output_human_check(data)
+    else:
+        output_json(data)
+
+    return 0 if unread else 1
+
+
 def main() -> int:
     """Main entry point with subcommand dispatch."""
     if not WAGGLE_AVAILABLE:
@@ -768,6 +805,7 @@ def main() -> int:
         "send": cmd_send,
         "list": cmd_list,
         "read": cmd_read,
+        "check": cmd_check,
         "config": cmd_config,
     }
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -625,6 +625,41 @@ def cmd_config(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     return 0 if smtp_valid else 1
 
 
+def cmd_list(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the list subcommand."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    try:
+        messages = list_inbox(
+            folder=args.folder,
+            limit=args.limit,
+            config=build_waggle_config(cfg),
+        )
+    except (ConnectionError, TimeoutError, OSError) as e:
+        logger.error(f"Failed to list messages: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error listing messages: {e}")
+        return 1
+
+    if args.unread:
+        messages = [m for m in messages if m.get("unread")]
+
+    data = {
+        "folder": args.folder,
+        "count": len(messages),
+        "messages": messages,
+    }
+
+    if args.human:
+        output_human_list(data)
+    else:
+        output_json(data)
+
+    return 0
+
+
 def main() -> int:
     """Main entry point with subcommand dispatch."""
     if not WAGGLE_AVAILABLE:
@@ -705,6 +740,7 @@ def main() -> int:
     # Dispatch to command handler
     commands = {
         "send": cmd_send,
+        "list": cmd_list,
         "config": cmd_config,
     }
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -3,43 +3,27 @@
 herd-mail: AI-to-AI communication facilitator for the herd.
 
 A secure, user-friendly wrapper for waggle that handles the full lifecycle
-of herd email communication: configuration, threading, duplication prevention,
-and sent-folder synchronization.
+of herd email communication: sending, reading, checking, and downloading.
 
-Features:
-- Markdown to HTML conversion with optional rich formatting
-- Thread-aware replies (fetches original for quoting)
-- Attachment support with security validation
-- Duplicate prevention (checks send log)
-- Automatic Sent folder saving via IMAP
-- Environment-based configuration (no hardcoded credentials)
+Commands:
+    herd_mail.py send --to recipient@example.com --subject "Hello" --body "Message"
+    herd_mail.py list [--folder INBOX] [--limit 20] [--unread] [--human]
+    herd_mail.py read <uid> [--folder INBOX] [--human]
+    herd_mail.py check [--folder INBOX] [--human]
+    herd_mail.py download <uid> [--folder INBOX] [--dest-dir .]
+    herd_mail.py config
 
-Usage:
-    # Send simple email
-    python3 herd_mail.py --to recipient@example.com --subject "Hello" --body "Message"
-
-    # Send with body from file
-    python3 herd_mail.py --to recipient@example.com --subject "Hello" --body-file message.md
-
-    # Reply to a message (auto-fetches original for threading)
-    python3 herd_mail.py --message-id 42 --to sender@example.com --subject "Re: Hello"
-
-    # With attachment
-    python3 herd_mail.py --to recipient@example.com --body "See attached" --attachment file.pdf
-
-    # Rich HTML formatting (requires markdown + pygments)
-    python3 herd_mail.py --to recipient@example.com --body-file message.md --rich
-
-Environment Variables (all optional, see .envrc.template):
+Environment Variables (see .envrc.template):
     WAGGLE_HOST         SMTP host
     WAGGLE_PORT         SMTP port (default: 465)
-    WAGGLE_USER         SMTP username
-    WAGGLE_PASS         SMTP password
+    WAGGLE_USER         SMTP/IMAP username
+    WAGGLE_PASS         SMTP/IMAP password
     WAGGLE_FROM         From email address
     WAGGLE_NAME         Display name
     WAGGLE_TLS          Use TLS (default: true)
-    WAGGLE_IMAP_HOST    IMAP host (for Sent folder)
+    WAGGLE_IMAP_HOST    IMAP host (required for list/read/check/download)
     WAGGLE_IMAP_PORT    IMAP port (default: 993)
+    WAGGLE_IMAP_TLS     Use IMAP TLS (default: true)
     WAGGLE_TO           Default test recipient
     WAGGLE_SEND_LOG     Path to send log (for duplicate detection)
     WAGGLE_DEV_PATH     Optional: Path to local waggle for development

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -347,13 +347,14 @@ def get_config() -> dict[str, Any]:
     }
 
 
-def validate_config(cfg: dict[str, Any], require_smtp: bool = True) -> bool:
+def validate_config(cfg: dict[str, Any], require_smtp: bool = True, require_imap: bool = False) -> bool:
     """
     Validate configuration has required values.
 
     Args:
         cfg: Configuration dictionary
         require_smtp: Whether to require SMTP settings
+        require_imap: Whether to require IMAP settings
 
     Returns:
         True if valid, False otherwise
@@ -366,10 +367,13 @@ def validate_config(cfg: dict[str, Any], require_smtp: bool = True) -> bool:
             if not cfg.get(key):
                 errors.append(f"Missing {key} (set WAGGLE_{key.upper()})")
 
-        # Validate from_addr is a valid email
         from_addr = cfg.get("from_addr")
         if from_addr and not validate_email_address(from_addr):
             errors.append(f"Invalid from_addr email format: {from_addr}")
+
+    if require_imap:
+        if not cfg.get("imap_host"):
+            errors.append("Missing imap_host (set WAGGLE_IMAP_HOST)")
 
     if errors:
         logger.error("Configuration errors:")

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -470,57 +470,8 @@ def output_human_check(data: dict[str, Any]) -> None:
         print(f"{count} unread message(s) in {folder}.")
 
 
-def main() -> int:
-    """
-    Main entry point.
-
-    Returns:
-        Exit code (0 for success, 1 for error)
-    """
-    # Check if waggle is available (unless we're just validating imports for tests)
-    if not WAGGLE_AVAILABLE:
-        logger.error("Error: waggle not installed. Run: pip install waggle-mail")
-        if WAGGLE_IMPORT_ERROR:
-            logger.error(f"Details: {WAGGLE_IMPORT_ERROR}")
-        return 1
-
-    parser = argparse.ArgumentParser(
-        description="Send herd emails with Markdown, attachments, and threading via waggle",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s --to friend@example.com --subject "Hello" --body "Hi there!"
-  %(prog)s --to friend@example.com --subject "Hello" --body-file message.md
-  %(prog)s --message-id 42 --to sender@example.com --subject "Re: Hello"
-  %(prog)s --to friend@example.com --body "See attached" --attachment doc.pdf
-        """
-    )
-
-    parser.add_argument("--to", required=True,
-                        help="Recipient email address")
-    parser.add_argument("--subject", required=True,
-                        help="Email subject line")
-    parser.add_argument("--body",
-                        help="Email body (Markdown supported)")
-    parser.add_argument("--body-file",
-                        help="Read body from file (UTF-8)")
-    parser.add_argument("--attachment", nargs="+",
-                        help="File(s) to attach")
-    parser.add_argument("--cc",
-                        help="CC recipients (comma-separated)")
-    parser.add_argument("--reply-to",
-                        help="Reply-To address")
-    parser.add_argument("--message-id",
-                        help="IMAP message ID to reply to (enables threading)")
-    parser.add_argument("--rich", action="store_true",
-                        help="Enable rich HTML formatting (requires markdown, pygments)")
-    parser.add_argument("--skip-duplicate-check", action="store_true",
-                        help="Skip checking for recent duplicates")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Validate config without sending")
-
-    args = parser.parse_args()
-
+def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the send subcommand."""
     # Validate email addresses early
     if not validate_email_address(args.to):
         logger.error(f"Invalid recipient email address: {sanitize_for_display(args.to)}")
@@ -534,27 +485,12 @@ Examples:
         logger.error(f"Invalid Reply-To email address: {sanitize_for_display(args.reply_to)}")
         return 1
 
-    # Load configuration
-    try:
-        cfg = get_config()
-    except ValueError as e:
-        logger.error(f"Configuration error: {e}")
-        return 1
-
+    # Handle --dry-run as alias for config command
     if args.dry_run:
-        if validate_config(cfg):
-            logger.info("Configuration valid!")
-            # Don't expose full username in output for security
-            smtp_user_display = cfg['smtp_user'][:3] + "***" if cfg['smtp_user'] else "***"
-            logger.info(f"  SMTP: {smtp_user_display}@{cfg['smtp_host']}:{cfg['smtp_port']}")
-            logger.info(f"  From: {cfg['from_name']} <{cfg['from_addr']}>")
-            if cfg.get("imap_host"):
-                logger.info(f"  IMAP: {cfg['imap_host']}:{cfg['imap_port']} (Sent folder enabled)")
-            return 0
-        return 1
+        return cmd_config(args, cfg)
 
-    # Validate configuration
-    if not validate_config(cfg):
+    # Validate SMTP configuration
+    if not validate_config(cfg, require_smtp=True):
         return 1
 
     # Get body content
@@ -574,10 +510,8 @@ Examples:
             logger.error(f"Error reading body file: {e}")
             return 1
     elif args.body:
-        # Decode common escape sequences from command line
         body = decode_escape_sequences(args.body)
     else:
-        # Try reading from stdin
         if not sys.stdin.isatty():
             try:
                 body = sys.stdin.read()
@@ -597,11 +531,11 @@ Examples:
                 config=build_waggle_config(cfg)
             ):
                 logger.warning(
-                    f"⚠️  Duplicate detected: recently sent to "
+                    f"Duplicate detected: recently sent to "
                     f"{sanitize_for_display(args.to)} with similar subject"
                 )
                 logger.info("Use --skip-duplicate-check to override")
-                return 0  # Not an error, just skipped
+                return 0
         except (OSError, ValueError) as e:
             logger.warning(f"Could not check for duplicates: {e}")
             logger.info("Continuing anyway...")
@@ -647,28 +581,140 @@ Examples:
             config=build_waggle_config(cfg),
         )
 
-        logger.info("✓ Email sent successfully!")
+        logger.info("Email sent successfully!")
         if cfg.get("imap_host"):
             logger.info("  (Saved to Sent folder via IMAP)")
 
         return 0
 
     except ConnectionError as e:
-        logger.error(f"✗ Connection error: {e}")
+        logger.error(f"Connection error: {e}")
         return 1
     except TimeoutError as e:
-        logger.error(f"✗ Timeout error: {e}")
+        logger.error(f"Timeout error: {e}")
         return 1
     except ValueError as e:
-        logger.error(f"✗ Invalid input: {e}")
+        logger.error(f"Invalid input: {e}")
         return 1
     except OSError as e:
-        logger.error(f"✗ I/O error: {e}")
+        logger.error(f"I/O error: {e}")
         return 1
     except Exception as e:
-        logger.error(f"✗ Unexpected error: {e}")
-        logger.debug("", exc_info=True)  # Full traceback in debug mode
+        logger.error(f"Unexpected error: {e}")
+        logger.debug("", exc_info=True)
         return 1
+
+
+def cmd_config(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the config subcommand. Validates SMTP and IMAP settings."""
+    smtp_valid = validate_config(cfg, require_smtp=True, require_imap=False)
+
+    if smtp_valid:
+        logger.info("SMTP configuration valid.")
+        smtp_user_display = cfg['smtp_user'][:3] + "***" if cfg['smtp_user'] else "***"
+        logger.info(f"  SMTP: {smtp_user_display}@{cfg['smtp_host']}:{cfg['smtp_port']}")
+        logger.info(f"  From: {cfg['from_name']} <{cfg['from_addr']}>")
+    else:
+        logger.error("SMTP configuration invalid.")
+
+    if cfg.get("imap_host"):
+        logger.info(f"  IMAP: {cfg['imap_host']}:{cfg['imap_port']} (configured)")
+    else:
+        logger.warning("  IMAP: not configured (set WAGGLE_IMAP_HOST for read commands)")
+
+    return 0 if smtp_valid else 1
+
+
+def main() -> int:
+    """Main entry point with subcommand dispatch."""
+    if not WAGGLE_AVAILABLE:
+        logger.error("Error: waggle not installed. Run: pip install waggle-mail")
+        if WAGGLE_IMPORT_ERROR:
+            logger.error(f"Details: {WAGGLE_IMPORT_ERROR}")
+        return 1
+
+    # Backward compat: detect old-style invocation (no subcommand, but --to present)
+    if len(sys.argv) > 1 and sys.argv[1].startswith('--'):
+        if '--to' in sys.argv:
+            logger.warning("Deprecation warning: use 'herd_mail.py send --to ...' instead")
+            sys.argv.insert(1, 'send')
+        elif '--dry-run' in sys.argv:
+            logger.warning("Deprecation warning: use 'herd_mail.py config' instead")
+            sys.argv.insert(1, 'send')
+
+    parser = argparse.ArgumentParser(
+        description="herd-mail: AI-to-AI email communication via waggle",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # send subcommand
+    send_parser = subparsers.add_parser("send", help="Send an email")
+    send_parser.add_argument("--to", required=True, help="Recipient email address")
+    send_parser.add_argument("--subject", required=True, help="Email subject line")
+    send_parser.add_argument("--body", help="Email body (Markdown supported)")
+    send_parser.add_argument("--body-file", help="Read body from file (UTF-8)")
+    send_parser.add_argument("--attachment", nargs="+", help="File(s) to attach")
+    send_parser.add_argument("--cc", help="CC recipients (comma-separated)")
+    send_parser.add_argument("--reply-to", help="Reply-To address")
+    send_parser.add_argument("--message-id", help="IMAP message ID to reply to (enables threading)")
+    send_parser.add_argument("--rich", action="store_true", help="Enable rich HTML formatting")
+    send_parser.add_argument("--skip-duplicate-check", action="store_true", help="Skip duplicate detection")
+    send_parser.add_argument("--dry-run", action="store_true", help="Validate config without sending")
+
+    # list subcommand
+    list_parser = subparsers.add_parser("list", help="List messages in a folder")
+    list_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    list_parser.add_argument("--limit", type=int, default=DEFAULT_LIST_LIMIT, help="Max messages (default: 20)")
+    list_parser.add_argument("--unread", action="store_true", help="Only show unread messages")
+    list_parser.add_argument("--human", action="store_true", help="Human-readable output")
+
+    # read subcommand
+    read_parser = subparsers.add_parser("read", help="Read a full message by UID")
+    read_parser.add_argument("uid", help="IMAP message UID")
+    read_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    read_parser.add_argument("--human", action="store_true", help="Human-readable output")
+
+    # check subcommand
+    check_parser = subparsers.add_parser("check", help="Check for unread messages")
+    check_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    check_parser.add_argument("--human", action="store_true", help="Human-readable output")
+
+    # download subcommand
+    dl_parser = subparsers.add_parser("download", help="Download attachments from a message")
+    dl_parser.add_argument("uid", help="IMAP message UID")
+    dl_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="IMAP folder (default: INBOX)")
+    dl_parser.add_argument("--dest-dir", default=".", help="Destination directory (default: .)")
+
+    # config subcommand
+    subparsers.add_parser("config", help="Validate configuration")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Load configuration
+    try:
+        cfg = get_config()
+    except ValueError as e:
+        logger.error(f"Configuration error: {e}")
+        return 1
+
+    # Dispatch to command handler
+    commands = {
+        "send": cmd_send,
+        "config": cmd_config,
+    }
+
+    handler = commands.get(args.command)
+    if handler:
+        return handler(args, cfg)
+
+    # Placeholder for read-side commands (implemented in later tasks)
+    logger.error(f"Command '{args.command}' not yet implemented")
+    return 1
 
 
 if __name__ == "__main__":

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -8,6 +8,7 @@ Or: python3 test_herd_mail.py (for basic validation)
 These tests mock SMTP/IMAP so they run without real credentials.
 """
 
+import json
 import os
 import sys
 import tempfile
@@ -514,6 +515,91 @@ class TestBodyLoading(unittest.TestCase):
             result = hm.main()
 
         self.assertEqual(result, 1)
+
+
+class TestOutput(unittest.TestCase):
+    """Test output formatting helpers."""
+
+    def test_output_json(self):
+        """Test JSON output goes to stdout."""
+        data = {"folder": "INBOX", "count": 1, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_json(data)
+        result = json.loads(captured.getvalue())
+        self.assertEqual(result["folder"], "INBOX")
+        self.assertEqual(result["count"], 1)
+
+    def test_output_human_list_with_messages(self):
+        """Test human-readable list output."""
+        data = {
+            "folder": "INBOX",
+            "count": 1,
+            "messages": [{
+                "uid": "42",
+                "from_addr": "alice@example.com",
+                "from_name": "Alice",
+                "subject": "Hello",
+                "date": "Mon, 24 Mar 2026 10:00:00 -0400",
+                "unread": True,
+                "size": 1024,
+            }]
+        }
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_list(data)
+        output = captured.getvalue()
+        self.assertIn("alice@example.com", output)
+        self.assertIn("Hello", output)
+
+    def test_output_human_list_empty(self):
+        """Test human-readable list output with no messages."""
+        data = {"folder": "INBOX", "count": 0, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_list(data)
+        output = captured.getvalue()
+        self.assertIn("No messages", output)
+
+    def test_output_human_read(self):
+        """Test human-readable read output."""
+        data = {
+            "uid": "42",
+            "folder": "INBOX",
+            "from_addr": "alice@example.com",
+            "from_name": "Alice",
+            "subject": "Hello",
+            "date": "Mon, 24 Mar 2026",
+            "to": "bob@example.com",
+            "body_plain": "Hi Bob!",
+            "body_html": None,
+            "attachments": [],
+        }
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_read(data)
+        output = captured.getvalue()
+        self.assertIn("From: Alice <alice@example.com>", output)
+        self.assertIn("Hi Bob!", output)
+
+    def test_output_human_check_with_unread(self):
+        """Test human-readable check output with unread messages."""
+        data = {"folder": "INBOX", "unread_count": 3, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_check(data)
+        output = captured.getvalue()
+        self.assertIn("3", output)
+        self.assertIn("unread", output)
+
+    def test_output_human_check_none_unread(self):
+        """Test human-readable check output with no unread messages."""
+        data = {"folder": "INBOX", "unread_count": 0, "messages": []}
+        captured = StringIO()
+        with patch('sys.stdout', captured):
+            hm.output_human_check(data)
+        output = captured.getvalue()
+        self.assertIn("No unread", output)
 
 
 class TestWaggleStubs(unittest.TestCase):

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -939,6 +939,82 @@ class TestCmdCheck(unittest.TestCase):
         self.assertIn("unread", output)
 
 
+class TestCmdDownload(unittest.TestCase):
+    """Test download subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.download_attachments')
+    def test_download_files(self, mock_dl):
+        """Test download returns file paths as JSON."""
+        mock_dl.return_value = ["/tmp/report.pdf", "/tmp/data.csv"]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["uid"], "42")
+        self.assertEqual(len(data["files"]), 2)
+
+    @patch('herd_mail.download_attachments')
+    def test_download_no_attachments(self, mock_dl):
+        """Test download with no attachments returns empty list."""
+        mock_dl.return_value = []
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["files"], [])
+
+    @patch('herd_mail.download_attachments')
+    def test_download_with_dest_dir(self, mock_dl):
+        """Test download with --dest-dir."""
+        mock_dl.return_value = ["/custom/dir/file.pdf"]
+        captured = StringIO()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('sys.argv', ['herd_mail.py', 'download', '42', '--dest-dir', tmpdir]):
+                with patch('sys.stdout', captured):
+                    result = hm.main()
+        self.assertEqual(result, 0)
+        mock_dl.assert_called_once()
+        self.assertTrue(tmpdir in str(mock_dl.call_args))
+
+    @patch('herd_mail.download_attachments')
+    def test_download_connection_error(self, mock_dl):
+        """Test download handles connection errors."""
+        mock_dl.side_effect = ConnectionError("Connection refused")
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+    def test_download_no_imap(self):
+        """Test download fails without IMAP config."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'download', '42']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+
 class TestWaggleStubs(unittest.TestCase):
     """Test that waggle function stubs exist for mocking."""
 

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -492,6 +492,18 @@ class TestBodyLoading(unittest.TestCase):
         self.assertEqual(result, 1)
 
 
+class TestWaggleStubs(unittest.TestCase):
+    """Test that waggle function stubs exist for mocking."""
+
+    def test_stubs_exist(self):
+        """All waggle functions should be importable from herd_mail."""
+        self.assertTrue(hasattr(hm, 'send_email'))
+        self.assertTrue(hasattr(hm, 'check_recently_sent'))
+        self.assertTrue(hasattr(hm, 'read_message'))
+        self.assertTrue(hasattr(hm, 'list_inbox'))
+        self.assertTrue(hasattr(hm, 'download_attachments'))
+
+
 def run_basic_tests():
     """Run basic tests without pytest."""
     print("Running basic validation tests...")

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -681,6 +681,101 @@ class TestBackwardCompat(unittest.TestCase):
         self.assertEqual(result, 1)
 
 
+class TestCmdList(unittest.TestCase):
+    """Test list subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.list_inbox')
+    def test_list_json_output(self, mock_list):
+        """Test list outputs JSON to stdout."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "alice@example.com", "from_name": "Alice",
+             "subject": "Hello", "date": "Mon, 24 Mar 2026", "flags": "",
+             "unread": True, "size": 1024},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["messages"][0]["from_addr"], "alice@example.com")
+
+    @patch('herd_mail.list_inbox')
+    def test_list_unread_filter(self, mock_list):
+        """Test --unread filters to unread only."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "a@example.com", "from_name": "A",
+             "subject": "Read", "date": "Mon", "flags": "\\Seen",
+             "unread": False, "size": 100},
+            {"uid": "2", "from_addr": "b@example.com", "from_name": "B",
+             "subject": "Unread", "date": "Tue", "flags": "",
+             "unread": True, "size": 200},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list', '--unread']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["messages"][0]["uid"], "2")
+
+    @patch('herd_mail.list_inbox')
+    def test_list_empty(self, mock_list):
+        """Test list with empty inbox."""
+        mock_list.return_value = []
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["count"], 0)
+
+    @patch('herd_mail.list_inbox')
+    def test_list_human_output(self, mock_list):
+        """Test list with --human flag."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "alice@example.com", "from_name": "Alice",
+             "subject": "Hello", "date": "Mon, 24 Mar 2026", "flags": "",
+             "unread": True, "size": 1024},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'list', '--human']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("alice@example.com", output)
+
+    def test_list_no_imap(self):
+        """Test list fails without IMAP config."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'list']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+
 class TestWaggleStubs(unittest.TestCase):
     """Test that waggle function stubs exist for mocking."""
 

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -249,6 +249,30 @@ class TestConfig(unittest.TestCase):
         result = hm.validate_config(cfg)
         self.assertTrue(result)
 
+    def test_validate_config_require_imap_missing(self):
+        """Test validation fails when IMAP required but missing."""
+        cfg = {
+            "smtp_host": "smtp.example.com",
+            "smtp_user": "user@example.com",
+            "smtp_pass": "secret",
+            "from_addr": "user@example.com",
+            "imap_host": None,
+        }
+        result = hm.validate_config(cfg, require_smtp=False, require_imap=True)
+        self.assertFalse(result)
+
+    def test_validate_config_require_imap_present(self):
+        """Test validation passes when IMAP required and present."""
+        cfg = {
+            "smtp_host": "smtp.example.com",
+            "smtp_user": "user@example.com",
+            "smtp_pass": "secret",
+            "from_addr": "user@example.com",
+            "imap_host": "imap.example.com",
+        }
+        result = hm.validate_config(cfg, require_smtp=False, require_imap=True)
+        self.assertTrue(result)
+
 
 class TestWaggleConfig(unittest.TestCase):
     """Test conversion to waggle's config format."""

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -856,6 +856,89 @@ class TestCmdRead(unittest.TestCase):
         self.assertEqual(result, 1)
 
 
+class TestCmdCheck(unittest.TestCase):
+    """Test check subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.list_inbox')
+    def test_check_has_unread(self, mock_list):
+        """Test check returns 0 when unread messages exist."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "a@example.com", "from_name": "A",
+             "subject": "New", "date": "Mon", "flags": "",
+             "unread": True, "size": 100},
+            {"uid": "2", "from_addr": "b@example.com", "from_name": "B",
+             "subject": "Read", "date": "Tue", "flags": "\\Seen",
+             "unread": False, "size": 200},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'check']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["unread_count"], 1)
+
+    @patch('herd_mail.list_inbox')
+    def test_check_no_unread(self, mock_list):
+        """Test check returns 1 when no unread messages."""
+        mock_list.return_value = [
+            {"uid": "1", "from_addr": "a@example.com", "from_name": "A",
+             "subject": "Read", "date": "Mon", "flags": "\\Seen",
+             "unread": False, "size": 100},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'check']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 1)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["unread_count"], 0)
+
+    @patch('herd_mail.list_inbox')
+    def test_check_connection_error(self, mock_list):
+        """Test check returns 2 on error."""
+        mock_list.side_effect = ConnectionError("Connection refused")
+        with patch('sys.argv', ['herd_mail.py', 'check']):
+            result = hm.main()
+        self.assertEqual(result, 2)
+
+    @patch('herd_mail.list_inbox')
+    def test_check_human_output(self, mock_list):
+        """Test check with --human flag."""
+        mock_list.return_value = [
+            {"uid": "1", "unread": True, "from_addr": "a@example.com",
+             "from_name": "A", "subject": "New", "date": "Mon",
+             "flags": "", "size": 100},
+        ]
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'check', '--human']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("1", output)
+        self.assertIn("unread", output)
+
+
 class TestWaggleStubs(unittest.TestCase):
     """Test that waggle function stubs exist for mocking."""
 

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -776,6 +776,86 @@ class TestCmdList(unittest.TestCase):
         self.assertEqual(result, 1)
 
 
+class TestCmdRead(unittest.TestCase):
+    """Test read subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.read_message')
+    def test_read_json_output(self, mock_read):
+        """Test read outputs full message as JSON."""
+        mock_read.return_value = {
+            "uid": "42", "folder": "INBOX",
+            "message_id": "<abc@example.com>",
+            "from_addr": "alice@example.com", "from_name": "Alice",
+            "subject": "Hello", "date": "Mon, 24 Mar 2026",
+            "to": "bob@example.com",
+            "body_plain": "Hi Bob!", "body_html": None,
+            "in_reply_to": None, "references": None,
+            "attachments": [],
+        }
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'read', '42']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["uid"], "42")
+        self.assertEqual(data["body_plain"], "Hi Bob!")
+
+    @patch('herd_mail.read_message')
+    def test_read_human_output(self, mock_read):
+        """Test read with --human flag."""
+        mock_read.return_value = {
+            "uid": "42", "folder": "INBOX",
+            "from_addr": "alice@example.com", "from_name": "Alice",
+            "subject": "Hello", "date": "Mon, 24 Mar 2026",
+            "to": "bob@example.com",
+            "body_plain": "Hi Bob!", "body_html": None,
+            "attachments": [],
+        }
+        captured = StringIO()
+        with patch('sys.argv', ['herd_mail.py', 'read', '42', '--human']):
+            with patch('sys.stdout', captured):
+                result = hm.main()
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("From: Alice <alice@example.com>", output)
+        self.assertIn("Hi Bob!", output)
+
+    @patch('herd_mail.read_message')
+    def test_read_connection_error(self, mock_read):
+        """Test read handles connection errors."""
+        mock_read.side_effect = ConnectionError("Connection refused")
+        with patch('sys.argv', ['herd_mail.py', 'read', '99']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+    def test_read_no_imap(self):
+        """Test read fails without IMAP config."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'read', '42']):
+            result = hm.main()
+        self.assertEqual(result, 1)
+
+
 class TestWaggleStubs(unittest.TestCase):
     """Test that waggle function stubs exist for mocking."""
 

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -1032,14 +1032,12 @@ def run_basic_tests():
     print("Running basic validation tests...")
     print("=" * 60)
 
-    # Test 1: Email validation
     print("\n1. Testing email validation...")
     assert hm.validate_email_address("user@example.com") == True
     assert hm.validate_email_address("invalid") == False
     assert hm.validate_email_address("user\n@example.com") == False
-    print("   ✓ Email validation works")
+    print("   Pass")
 
-    # Test 2: Port parsing
     print("\n2. Testing port parsing...")
     assert hm.parse_port("465", 0, "test") == 465
     try:
@@ -1047,21 +1045,18 @@ def run_basic_tests():
         assert False, "Should have raised ValueError"
     except ValueError:
         pass
-    print("   ✓ Port parsing works")
+    print("   Pass")
 
-    # Test 3: Escape sequences
     print("\n3. Testing escape sequences...")
     assert hm.decode_escape_sequences("hello\\nworld") == "hello\nworld"
     assert hm.decode_escape_sequences("hello\\\\world") == "hello\\world"
-    print("   ✓ Escape sequence handling works")
+    print("   Pass")
 
-    # Test 4: Sanitization
     print("\n4. Testing sanitization...")
     assert hm.sanitize_for_display("hello\x1b[31mworld") == "helloworld"
     assert hm.sanitize_for_display("hello\nworld") == "hello\nworld"
-    print("   ✓ Sanitization works")
+    print("   Pass")
 
-    # Test 5: Config loading
     print("\n5. Testing config loading...")
     os.environ["WAGGLE_HOST"] = "smtp.example.com"
     os.environ["WAGGLE_USER"] = "user@example.com"
@@ -1071,29 +1066,30 @@ def run_basic_tests():
     cfg = hm.get_config()
     assert cfg["smtp_host"] == "smtp.example.com"
     assert cfg["smtp_port"] == 465
-    print("   ✓ Config loads correctly")
+    print("   Pass")
 
-    # Test 6: Config validation
-    print("\n6. Testing config validation...")
-    assert hm.validate_config(cfg) == True
-    print("   ✓ Valid config passes")
+    print("\n6. Testing IMAP validation...")
+    assert hm.validate_config(cfg, require_smtp=False, require_imap=True) == False
+    cfg["imap_host"] = "imap.example.com"
+    assert hm.validate_config(cfg, require_smtp=False, require_imap=True) == True
+    print("   Pass")
 
-    incomplete = {"smtp_host": "", "smtp_user": "user", "smtp_pass": "pass", "from_addr": "user"}
-    assert hm.validate_config(incomplete) == False
-    print("   ✓ Invalid config fails correctly")
-
-    # Test 7: Waggle config conversion
-    print("\n7. Testing waggle config conversion...")
-    waggle_cfg = hm.build_waggle_config(cfg)
-    assert waggle_cfg["host"] == "smtp.example.com"
-    assert "imap_host" in waggle_cfg
-    print("   ✓ Config converts to waggle format")
+    print("\n7. Testing output helpers...")
+    import json
+    from io import StringIO
+    data = {"folder": "INBOX", "count": 0, "messages": []}
+    captured = StringIO()
+    import sys as _sys
+    old_stdout = _sys.stdout
+    _sys.stdout = captured
+    hm.output_json(data)
+    _sys.stdout = old_stdout
+    assert json.loads(captured.getvalue())["count"] == 0
+    print("   Pass")
 
     print("\n" + "=" * 60)
-    print("All basic tests passed! ✓")
-    print("\nFor full test suite, install pytest and run:")
-    print("  pip install pytest")
-    print("  python3 -m pytest test_herd_mail.py -v")
+    print("All basic tests passed!")
+    print("\nFor full test suite: python3 -m pytest test_herd_mail.py -v")
 
 
 if __name__ == "__main__":

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -339,7 +339,7 @@ class TestMain(unittest.TestCase):
         mock_check_duplicate.return_value = False
         mock_send.return_value = None
 
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'Hi there!']):
             result = hm.main()
 
@@ -355,7 +355,7 @@ class TestMain(unittest.TestCase):
         """Test duplicate detection prevents send."""
         mock_check_duplicate.return_value = True
 
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'Hi!']):
             result = hm.main()
 
@@ -367,7 +367,7 @@ class TestMain(unittest.TestCase):
         """Test --skip-duplicate-check bypasses detection."""
         mock_send.return_value = None
 
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'Hi!',
                                 '--skip-duplicate-check']):
             result = hm.main()
@@ -378,7 +378,7 @@ class TestMain(unittest.TestCase):
 
     def test_dry_run(self):
         """Test --dry-run validates without sending."""
-        with patch('sys.argv', ['herd_mail.py', '--dry-run', '--to', 'test@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--dry-run', '--to', 'test@example.com',
                                 '--subject', 'Test']):
             result = hm.main()
 
@@ -389,7 +389,7 @@ class TestMain(unittest.TestCase):
         self.clear_env()
         # Don't set any env vars
 
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'Hi!']):
             result = hm.main()
 
@@ -397,7 +397,7 @@ class TestMain(unittest.TestCase):
 
     def test_invalid_email_address(self):
         """Test error with invalid email address."""
-        with patch('sys.argv', ['herd_mail.py', '--to', 'not_an_email',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'not_an_email',
                                 '--subject', 'Hello', '--body', 'Hi!']):
             result = hm.main()
 
@@ -405,7 +405,7 @@ class TestMain(unittest.TestCase):
 
     def test_invalid_cc_address(self):
         """Test error with invalid CC address."""
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'Hi!',
                                 '--cc', 'invalid_email']):
             result = hm.main()
@@ -419,7 +419,7 @@ class TestMain(unittest.TestCase):
         mock_check_duplicate.return_value = False
         mock_send.return_value = None
 
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'See attached',
                                 '--attachment', 'file1.pdf', 'file2.txt']):
             result = hm.main()
@@ -435,7 +435,7 @@ class TestMain(unittest.TestCase):
         mock_check_duplicate.return_value = False
         mock_send.return_value = None
 
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello', '--body', 'Line1\\nLine2']):
             result = hm.main()
 
@@ -479,7 +479,7 @@ class TestBodyLoading(unittest.TestCase):
             temp_path = f.name
 
         try:
-            with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+            with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                     '--subject', 'Hello', '--body-file', temp_path]):
                 result = hm.main()
 
@@ -499,7 +499,7 @@ class TestBodyLoading(unittest.TestCase):
         # Mock stdin
         with patch('sys.stdin', StringIO("Hello from stdin")):
             with patch('sys.stdin.isatty', return_value=False):
-                with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+                with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                         '--subject', 'Hello']):
                     result = hm.main()
 
@@ -509,7 +509,7 @@ class TestBodyLoading(unittest.TestCase):
 
     def test_body_file_not_found(self):
         """Test error when body file doesn't exist."""
-        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
                                 '--subject', 'Hello',
                                 '--body-file', '/tmp/nonexistent_file_12345.txt']):
             result = hm.main()
@@ -600,6 +600,85 @@ class TestOutput(unittest.TestCase):
             hm.output_human_check(data)
         output = captured.getvalue()
         self.assertIn("No unread", output)
+
+
+class TestCmdConfig(unittest.TestCase):
+    """Test config subcommand."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    def test_config_valid(self):
+        """Test config command with valid SMTP+IMAP config."""
+        with patch('sys.argv', ['herd_mail.py', 'config']):
+            result = hm.main()
+        self.assertEqual(result, 0)
+
+    def test_config_missing_imap(self):
+        """Test config command warns about missing IMAP."""
+        del os.environ["WAGGLE_IMAP_HOST"]
+        with patch('sys.argv', ['herd_mail.py', 'config']):
+            result = hm.main()
+        # config still succeeds if SMTP is valid, but warns about IMAP
+        self.assertEqual(result, 0)
+
+
+class TestBackwardCompat(unittest.TestCase):
+    """Test backward compatibility for old-style invocations."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.send_email')
+    @patch('herd_mail.check_recently_sent')
+    def test_old_style_send(self, mock_check, mock_send):
+        """Test old-style --to without subcommand still works."""
+        mock_check.return_value = False
+        mock_send.return_value = None
+
+        with patch('sys.argv', ['herd_mail.py', '--to', 'friend@example.com',
+                                '--subject', 'Hello', '--body', 'Hi!']):
+            result = hm.main()
+
+        self.assertEqual(result, 0)
+        mock_send.assert_called_once()
+
+    def test_no_args_shows_help(self):
+        """Test no arguments exits with error (help shown)."""
+        with patch('sys.argv', ['herd_mail.py']):
+            result = hm.main()
+        self.assertEqual(result, 1)
 
 
 class TestWaggleStubs(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Refactor herd_mail.py from flat flags to subcommand-based CLI: `send`, `list`, `read`, `check`, `download`, `config`
- JSON-first output for AI agent consumption (stdout=JSON, stderr=logging) with `--human` flag for readable output
- `check` command uses exit code semantics for polling loops (0=unread, 1=none, 2=error)
- Backward compatible: old-style `herd_mail.py --to ...` still works with deprecation warning

## Test plan

- [x] 61/61 tests passing (up from 30)
- [x] All subcommands tested: happy path, error handling, JSON + human output
- [x] Backward compatibility tested (old-style send, no-args help)
- [x] IMAP config validation tested for read-side commands
- [x] Code review completed — 3 identified issues fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)