### PR TITLE
Fix missing quoted body in replies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Optional vars: `WAGGLE_IMAP_HOST` (required for read commands), `WAGGLE_IMAP_POR
 
 ### Single-file Design
 
-Everything lives in `herd_mail.py` (≈1100 lines) with tests in `test_herd_mail.py`. No package structure.
+Everything lives in `herd_mail.py` (~1300 lines) with tests in `test_herd_mail.py` (~1750 lines). No package structure.
 
 ### Subcommand Dispatch
 
@@ -110,7 +110,7 @@ Auto-flag operations are non-fatal (warning on failure, command still succeeds).
 
 ## Security
 
-See `SECURITY_FIXES.md` for full details. Key protections:
+Key protections:
 - Email header injection prevention (validates addresses)
 - Path traversal protection (blocks sensitive dirs like `/etc`, `/proc`)
 - ANSI escape stripping for terminal output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ herd-mail is a CLI wrapper for [waggle](https://github.com/jasonacox-sam/waggle-
 
 This is a standalone Python script, not a package. No build system or setup.py required.
 
-**Version 3.0**: Subcommand-based CLI (`send`, `list`, `read`, `check`, `download`, `flag`, `move`, `config`). JSON-first output for AI agents (stdout=JSON, stderr=logging).
+**Version 3.1**: Subcommand-based CLI (`send`, `list`, `read`, `check`, `download`, `flag`, `move`, `config`). JSON-first output for AI agents (stdout=JSON, stderr=logging). Version tracked via `__version__` in `herd_mail.py`, `--version` flag, and `config` output. Keep `__version__` and `pyproject.toml` version in sync.
 
 ## Development Commands
 
@@ -32,15 +32,17 @@ python3 test_herd_mail.py
 python3 herd_mail.py config
 ```
 
-**Test Coverage**: ~95% | **Tests**: 97 passing
+**Test Coverage**: ~95% | **Tests**: 105 passing
 
 Tests mock SMTP/IMAP so they run without real credentials. Tests use `unittest.TestCase` classes, not pytest fixtures.
 
 ### Dependencies
+
+Defined in `pyproject.toml`. Install with:
 ```bash
-pip install waggle-mail          # Required
-pip install markdown pygments    # Optional (for --rich flag)
-pip install pytest               # For testing
+pip install .                    # Core (waggle-mail)
+pip install ".[rich]"            # + markdown/pygments for --rich flag
+pip install ".[dev]"             # + pytest
 ```
 
 ## Configuration

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -428,6 +428,29 @@ def build_waggle_config(cfg: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def format_quote_block(original: dict[str, Any]) -> str:
+    """Format an already-fetched message as an Outlook-style quoted block.
+
+    This avoids relying on waggle's fetch_quoted_body(), which re-fetches
+    the message via IMAP SEARCH by Message-ID — a search that fails on
+    some providers (e.g., Amazon WorkMail).
+    """
+    from_raw = original.get("from_raw", "")
+    date = original.get("date", "")
+    subject = original.get("subject", "")
+    body_plain = original.get("body_plain") or ""
+
+    header = (
+        f"\n\n-----Original Message-----\n"
+        f"From: {from_raw}\n"
+        f"Sent: {date}\n"
+        f"Subject: {subject}\n"
+    )
+    if body_plain.strip():
+        return header + "\n" + body_plain.strip()
+    return header
+
+
 def save_to_sent(
     cfg: dict[str, Any],
     to: str,
@@ -867,6 +890,9 @@ def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
             )
             in_reply_to = original.get("message_id")
             references = original.get("reply_references")
+            # Append quoted original — waggle's fetch_quoted_body re-fetches
+            # via IMAP SEARCH by Message-ID which fails on some providers
+            body += format_quote_block(original)
             subject = sanitize_for_display(original.get('subject', 'Unknown'))
             logger.info(f"  Found: {subject}")
         except (ConnectionError, TimeoutError, OSError) as e:

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -32,6 +32,8 @@ Author: O.C.
 License: MIT
 """
 
+__version__ = "3.1.0"
+
 import argparse
 import imaplib
 import json
@@ -966,6 +968,7 @@ def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
 
 def cmd_config(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     """Handle the config subcommand. Validates SMTP and IMAP settings."""
+    logger.info(f"herd-mail {__version__}")
     smtp_valid = validate_config(cfg, require_smtp=True, require_imap=False)
 
     if smtp_valid:
@@ -1236,6 +1239,7 @@ def main() -> int:
         description="herd-mail: AI-to-AI email communication via waggle",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument("--version", action="version", version=f"herd-mail {__version__}")
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # send subcommand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "herd-mail"
+version = "3.1.0"
+description = "AI-to-AI email communication CLI via waggle"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.8"
+dependencies = [
+    "waggle-mail>=1.8.7",
+]
+
+[project.optional-dependencies]
+rich = [
+    "markdown>=3.4",
+    "pygments>=2.14",
+]
+dev = [
+    "pytest>=7.0",
+]

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -1674,6 +1674,120 @@ class TestAutoFlagOnReply(unittest.TestCase):
         self.assertEqual(result, 0)
 
 
+class TestFormatQuoteBlock(unittest.TestCase):
+    """Test formatting of quoted original message for replies."""
+
+    def test_formats_quote_with_body(self):
+        """Quote block includes header and body text."""
+        original = {
+            "from_raw": "Alice <alice@example.com>",
+            "date": "Tue, 01 Apr 2026 10:30:00 +0000",
+            "subject": "Project update",
+            "body_plain": "Here is the update.\nSecond line.",
+        }
+        result = hm.format_quote_block(original)
+        self.assertIn("-----Original Message-----", result)
+        self.assertIn("From: Alice <alice@example.com>", result)
+        self.assertIn("Sent: Tue, 01 Apr 2026 10:30:00 +0000", result)
+        self.assertIn("Subject: Project update", result)
+        self.assertIn("Here is the update.", result)
+        self.assertIn("Second line.", result)
+
+    def test_formats_quote_without_body(self):
+        """Quote block works when original has no body."""
+        original = {
+            "from_raw": "Bob <bob@example.com>",
+            "date": "Wed, 02 Apr 2026 12:00:00 +0000",
+            "subject": "Empty",
+            "body_plain": None,
+        }
+        result = hm.format_quote_block(original)
+        self.assertIn("-----Original Message-----", result)
+        self.assertIn("From: Bob <bob@example.com>", result)
+        self.assertNotIn("None", result)
+
+    def test_formats_quote_missing_fields(self):
+        """Quote block handles missing dict keys gracefully."""
+        original = {}
+        result = hm.format_quote_block(original)
+        self.assertIn("-----Original Message-----", result)
+
+
+class TestReplyQuotedBody(unittest.TestCase):
+    """Test that cmd_send appends quoted original to reply body."""
+
+    def setUp(self):
+        self.clear_env()
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+        os.environ["WAGGLE_IMAP_HOST"] = "imap.example.com"
+        self.waggle_patch = patch('herd_mail.WAGGLE_AVAILABLE', True)
+        self.waggle_patch.start()
+
+    def tearDown(self):
+        self.waggle_patch.stop()
+        self.clear_env()
+
+    def clear_env(self):
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+
+    @patch('herd_mail.imap_store_flags')
+    @patch('herd_mail.save_to_sent')
+    @patch('herd_mail.send_email')
+    @patch('herd_mail.read_message')
+    @patch('herd_mail.check_recently_sent')
+    def test_reply_includes_quoted_original(self, mock_check, mock_read_msg,
+                                             mock_send, mock_save, mock_store):
+        """Reply body sent to send_email includes quoted original message."""
+        mock_check.return_value = False
+        mock_read_msg.return_value = {
+            "message_id": "<orig@example.com>",
+            "reply_references": "<orig@example.com>",
+            "subject": "Original Subject",
+            "from_raw": "Alice <alice@example.com>",
+            "date": "Tue, 01 Apr 2026 10:30:00 +0000",
+            "body_plain": "Original body text here.",
+        }
+        mock_send.return_value = None
+        mock_save.return_value = True
+        mock_store.return_value = {"results": [{"uid": "42", "status": "ok"}]}
+
+        with patch('sys.argv', ['herd_mail.py', 'send', '--message-id', '42',
+                                '--to', 'alice@example.com',
+                                '--subject', 'Re: Original Subject',
+                                '--body', 'Thanks for the update!']):
+            result = hm.main()
+
+        self.assertEqual(result, 0)
+        body_sent = mock_send.call_args[1].get('body_md') or mock_send.call_args[0][2]
+        self.assertIn("Thanks for the update!", body_sent)
+        self.assertIn("-----Original Message-----", body_sent)
+        self.assertIn("Original body text here.", body_sent)
+
+    @patch('herd_mail.imap_store_flags')
+    @patch('herd_mail.save_to_sent')
+    @patch('herd_mail.send_email')
+    @patch('herd_mail.read_message')
+    @patch('herd_mail.check_recently_sent')
+    def test_non_reply_no_quote(self, mock_check, mock_send_email,
+                                 mock_send, mock_save, mock_store):
+        """Non-reply send does not add any quote block."""
+        mock_check.return_value = False
+        mock_send.return_value = None
+
+        with patch('sys.argv', ['herd_mail.py', 'send', '--to', 'friend@example.com',
+                                '--subject', 'Hello', '--body', 'Just a message']):
+            result = hm.main()
+
+        self.assertEqual(result, 0)
+        body_sent = mock_send.call_args[1].get('body_md') or mock_send.call_args[0][2]
+        self.assertNotIn("-----Original Message-----", body_sent)
+
+
 class TestWaggleStubs(unittest.TestCase):
     """Test that waggle function stubs exist for mocking."""
 

--- a/test_herd_mail.py
+++ b/test_herd_mail.py
@@ -23,6 +23,48 @@ sys.path.insert(0, str(Path(__file__).parent))
 import herd_mail as hm
 
 
+class TestVersion(unittest.TestCase):
+    """Test version tracking."""
+
+    def test_version_string_exists(self):
+        """Module has a __version__ attribute."""
+        self.assertTrue(hasattr(hm, '__version__'))
+        self.assertRegex(hm.__version__, r'^\d+\.\d+\.\d+')
+
+    def test_version_flag(self):
+        """--version prints version and exits."""
+        with patch('herd_mail.WAGGLE_AVAILABLE', True):
+            with self.assertRaises(SystemExit) as ctx:
+                with patch('sys.argv', ['herd_mail.py', '--version']):
+                    hm.main()
+            self.assertEqual(ctx.exception.code, 0)
+
+    def test_config_shows_version(self):
+        """Config output includes version."""
+        for key in list(os.environ.keys()):
+            if key.startswith("WAGGLE_"):
+                del os.environ[key]
+        os.environ["WAGGLE_HOST"] = "smtp.example.com"
+        os.environ["WAGGLE_USER"] = "user@example.com"
+        os.environ["WAGGLE_PASS"] = "secret"
+        os.environ["WAGGLE_FROM"] = "user@example.com"
+
+        try:
+            with patch('herd_mail.WAGGLE_AVAILABLE', True), \
+                 patch('sys.argv', ['herd_mail.py', 'config']), \
+                 patch('herd_mail.logger') as mock_logger:
+                hm.main()
+
+            log_output = " ".join(
+                str(call) for call in mock_logger.info.call_args_list
+            )
+            self.assertIn(hm.__version__, log_output)
+        finally:
+            for key in list(os.environ.keys()):
+                if key.startswith("WAGGLE_"):
+                    del os.environ[key]
+
+
 class TestEmailValidation(unittest.TestCase):
     """Test email address validation."""
 


### PR DESCRIPTION
## Summary
- Add `format_quote_block()` to build Outlook-style quote from already-fetched original message
- Append quoted original to reply body in `cmd_send` before calling waggle's `send_email()`
- Bypasses waggle's `fetch_quoted_body()` which fails silently on some IMAP providers (HEADER Message-ID search)

Fixes #3

## Test plan
- [ ] 5 new tests pass (3 unit for `format_quote_block`, 2 integration for reply quoting in `cmd_send`)
- [ ] Full suite passes (102 tests, up from 97)
- [ ] Smoke test: `herd_mail.py send --message-id <uid> --to ... --body "reply"` — verify quoted original appears in sent email

🤖 Generated with [Claude Code](https://claude.com/claude-code)