### PR TITLE
fix: remove UID-to-sequence conversion for waggle 1.9.12+

### DIFF
--- a/herd_mail.py
+++ b/herd_mail.py
@@ -849,13 +849,11 @@ def cmd_read(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     if not validate_config(cfg, require_smtp=False, require_imap=True):
         return 1
 
-    # Convert UID to sequence number for waggle (which expects sequence numbers)
-    seq_num = uid_to_sequence_number(cfg, args.uid, folder=args.folder)
-    waggle_id = seq_num if seq_num else args.uid
-
+    # waggle 1.9.12+ uses UID-based IMAP commands (m.uid("FETCH", ...))
+    # Pass the real UID directly — no sequence number conversion needed
     try:
         message = read_message(
-            waggle_id,
+            args.uid,
             folder=args.folder,
             config=build_waggle_config(cfg),
         )
@@ -871,7 +869,7 @@ def cmd_read(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     else:
         output_json(message)
 
-    # Use the real UID (not sequence number) for flag operations
+    # Mark as read using UID directly (waggle 1.9.12+ uses UID STORE)
     if not args.no_mark_read:
         try:
             read_message(


### PR DESCRIPTION
## Summary

waggle 1.9.12+ changed to use UID-based IMAP commands (`m.uid('FETCH', ...)` and `m.uid('STORE', ...)`) instead of sequence-number-based commands.

The `uid_to_sequence_number()` conversion in `cmd_read()` was passing sequence numbers where waggle now expects UIDs directly. This caused:
- `read` command failing with 'Message N not found'
- `read` auto-mark-read failing with 'Invalid messageset'

## Fix

Pass the real UID directly to `waggle.read_message()` and `waggle.set_flags()` without conversion.

## Changes

- Removed `uid_to_sequence_number()` call in `cmd_read()`
- Pass `args.uid` directly instead of converted sequence number
- Updated comment to reflect waggle 1.9.12+ UID STORE behavior

## Verification

- [x] `read --human` successfully fetches message content
- [x] Message is automatically marked as `\Seen` in one operation
- [x] No more 'Invalid messageset' errors
- [x] Tested with waggle 1.9.12 on AWS WorkMail

## Related Issues

Fixes #10
Fixes #9 (via waggle upgrade)

## Dependencies

Requires **waggle >= 1.9.12** (which fixes UID STORE and Sent folder detection)

## Breaking Change

This change requires waggle 1.9.12+. Users on older waggle versions will need to upgrade:
```bash
pip install --upgrade waggle-mail
```