### PR TITLE
feat: stats subcommand + version-controlled oc-helper scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install waggle-mail pytest
+          python -m pip install --upgrade pip
+          # Install the package with its declared runtime deps + dev extras
+          # (keeps CI in sync with pyproject.toml instead of a hardcoded list)
+          pip install -e .[dev]
 
       - name: Run tests
-        run: python3 -m pytest test_herd_mail.py -v
+        run: python -m pytest test_herd_mail.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ htmlcov/
 .DS_Store
 Thumbs.db
 docs/waggle-issues/
+
+# Runtime logs from helper scripts
+scripts/oc-helpers/*.log
+auto_file_noise.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`auto_file_noise.py --format json` crash:** `json` was used but never imported. Added the import.
+- **`requests` import crash:** v3.2.0 made `requests` a hard top-level import, which broke the CLI (and CI) anywhere `requests` wasn't installed. It is now a guarded optional import — the rotating footer degrades gracefully when `requests` is absent — and is declared as a real dependency in `pyproject.toml`.
+
+### CI / packaging
+
+- Declared `requests>=2.28` in `pyproject.toml` dependencies.
+- CI now installs the package itself (`pip install -e .[dev]`) so test dependencies stay in sync with `pyproject.toml` instead of a hardcoded list.
 
 ## [3.2.0] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-06-17
+
+### Added
+
+- **`stats` subcommand:** Reports per-folder message counts — total, unread, and received within the last N days — in a single IMAP connection. Use `herd_mail.py stats --human` for an aligned table over all folders, `--folder A,B` to limit, and `--days N` to set the recent window (default 7). JSON output by default; `--human` for a table. Replaces the need for one-off folder-census scripts.
+- **`scripts/oc-helpers/`:** Version-controlled, deployment-specific example wrappers and automation built on top of herd-mail (mail wrapper, noise auto-filer, subjects-only buzz scan, local-model triage digest). See `scripts/oc-helpers/README.md`. These are examples to adapt, not general-purpose tooling.
+- **Noise-filer activity log:** `auto_file_noise.py` now appends a tab-delimited, greppable log (one line per filed message + a per-run SUMMARY line). Configurable via `--log-file` / `NOISE_FILTER_LOG`; logs are gitignored.
+
+### Fixed
+
+- **`auto_file_noise.py --format json` crash:** `json` was used but never imported. Added the import.
+
+## [3.2.0] - 2026-05-14
+
+### Added
+
+- **Rotating adoption footer:** `send` can append a rotating footer fetched from the herd-inbox API (`--footer`, on by default; `--no-footer` to disable; `--footer-category`/`--footer-context` to filter). Requires `HERD_INBOX_ADMIN_KEY`; silently skipped if unset or the API is unreachable.
+
+### Dependencies
+
+- Adds `requests` (used by the footer fetch).
+
 ## [3.1.1] - 2026-04-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ A secure, user-friendly CLI wrapper for [waggle](https://github.com/jasonacox-sa
 - **Attachments**: Send files with security validation
 - **Duplicate Prevention**: Checks send log to prevent accidental resends
 - **Sent Folder Sync**: Saves plain text copy to IMAP Sent folder (when IMAP configured)
+- **Rotating Footer** (optional): Append a rotating adoption footer fetched from the herd-inbox API (`--footer`/`--no-footer`). Requires `HERD_INBOX_ADMIN_KEY` and `requests`; silently skipped if either is missing.
 
 ### Reading
 - **List Messages**: JSON output for AI agents, human-readable for interactive use
 - **Read Messages**: Full message content with headers, auto-marks as read
 - **Check for Unread**: Polling-friendly exit codes (0=has unread, 1=none, 2=error)
 - **Download Attachments**: Save attachments with path validation
+- **Folder Stats**: `stats` reports per-folder counts (total / unread / received in last N days) in a single IMAP pass — cheap way to answer "how's the mailbox doing?"
 
 ### Flag & Move
 - **Flag Management**: Add/remove `\Seen`, `\Answered`, `\Flagged` on messages
@@ -28,12 +30,18 @@ A secure, user-friendly CLI wrapper for [waggle](https://github.com/jasonacox-sa
 - **Auto-Flagging**: `read` marks `\Seen`; `send --message-id` marks `\Seen`+`\Answered`
 
 ### General
-- **Subcommand CLI**: `send`, `list`, `read`, `check`, `download`, `flag`, `move`, `config`
+- **Subcommand CLI**: `send`, `list`, `read`, `check`, `download`, `flag`, `move`, `stats`, `config`
 - **JSON-first Output**: Stdout for data, stderr for logging (AI-agent friendly)
 - **Environment-based**: No hardcoded credentials in scripts
 - **Security Hardened**: Email validation, path validation, injection prevention
 - **Type Safe**: Full type hints for Python 3.8+
 - **Backward Compatible**: Old `--to` syntax still works with deprecation warning
+
+### Example helpers (`scripts/oc-helpers/`)
+Version-controlled, deployment-specific automation built on top of herd-mail
+(mail wrapper, noise auto-filer with greppable activity log, subjects-only buzz
+scan, local-model triage digest). These are **adapt-me examples**, not
+general-purpose tooling — see [`scripts/oc-helpers/README.md`](scripts/oc-helpers/README.md).
 
 ## Quick Start
 
@@ -42,8 +50,10 @@ A secure, user-friendly CLI wrapper for [waggle](https://github.com/jasonacox-sa
 git clone <this-repo>
 cd herd-mail
 
-# Install dependencies
-pip install waggle-mail
+# Install dependencies (recommended: install the package + its declared deps)
+pip install -e .
+# ...or just the runtime libs directly:
+# pip install waggle-mail requests
 
 # Optional: rich formatting
 pip install markdown pygments
@@ -445,6 +455,43 @@ options:
   --human          Human-readable output
 ```
 
+### stats subcommand
+
+Report per-folder message counts in a single IMAP connection: total messages,
+unread (`UNSEEN`), and messages received within the last N days. Folders are
+auto-discovered (containers marked `\Noselect` are skipped) unless you pass
+`--folder`.
+
+```
+usage: herd_mail.py stats [-h] [--folder FOLDER] [--days DAYS] [--human]
+
+options:
+  --folder FOLDER  Comma-separated folders to measure (default: all folders)
+  --days DAYS      Window in days for the recent count (default: 7)
+  --human          Human-readable table output
+```
+
+```bash
+# All folders, last 7 days, as a table
+herd_mail.py stats --human
+
+# Specific folders, last 30 days, as JSON
+herd_mail.py stats --folder INBOX,Archive --days 30
+```
+
+JSON output shape:
+
+```json
+{
+  "days": 7,
+  "count": 2,
+  "folders": [
+    {"folder": "INBOX", "total": 4, "unread": 0, "recent": 4, "error": null},
+    {"folder": "Archive", "total": 1203, "unread": 0, "recent": 12, "error": null}
+  ]
+}
+```
+
 ## Testing
 
 Run the comprehensive test suite:
@@ -460,7 +507,7 @@ python3 test_herd_mail.py
 
 Tests mock SMTP/IMAP so they run without real credentials.
 
-**Test Coverage**: ~95% | **Tests**: 97 passing
+**Tests**: 92 passing (run on Python 3.10 / 3.12 / 3.14 in CI)
 
 ## How It Works
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -32,9 +32,10 @@ Author: O.C.
 License: MIT
 """
 
-__version__ = "3.1.0"
+__version__ = "3.3.0"
 
 import argparse
+import datetime
 import imaplib
 import json
 import logging
@@ -45,6 +46,8 @@ import sys
 from email.utils import parseaddr
 from pathlib import Path
 from typing import Any, Optional
+
+import requests  # noqa: E402
 
 # Constants
 DEFAULT_SMTP_PORT = 465
@@ -74,6 +77,49 @@ if WAGGLE_DEV_PATH:
         logger.info(f"Using development waggle from: {dev_path}")
     else:
         logger.warning(f"WAGGLE_DEV_PATH set but path doesn't exist: {dev_path}")
+
+# Herd-inbox footer API
+HERD_INBOX_URL = os.environ.get("HERD_INBOX_URL", "https://herd.mostlycopyandpaste.com")
+HERD_ADMIN_KEY = os.environ.get("HERD_INBOX_ADMIN_KEY", "")
+
+
+def fetch_footer(category: Optional[str] = None, context: Optional[str] = None, exclude_ids: Optional[list[int]] = None) -> Optional[str]:
+    """Fetch a rotating footer message from the herd-inbox API.
+
+    Args:
+        category: Filter by category (token_economics, social_proof, fomo, cheeky)
+        context: Filter by context (announcement, discussion)
+        exclude_ids: Footer IDs to exclude from selection
+
+    Returns:
+        Footer text string, or None if the API call fails.
+    """
+    if not HERD_ADMIN_KEY:
+        logger.debug("No HERD_INBOX_ADMIN_KEY set, skipping footer")
+        return None
+
+    params: dict[str, Any] = {}
+    if category:
+        params["category"] = category
+    if context:
+        params["context"] = context
+    if exclude_ids:
+        params["exclude"] = ",".join(str(i) for i in exclude_ids)
+
+    try:
+        resp = requests.get(
+            f"{HERD_INBOX_URL}/api/admin/footer",
+            headers={"X-Admin-Key": HERD_ADMIN_KEY},
+            params=params,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("footer")
+    except requests.RequestException as e:
+        logger.warning(f"Failed to fetch footer from herd-inbox: {e}")
+        return None
+
 
 # Try to import waggle, but don't exit at module level (allows tests to run)
 WAGGLE_AVAILABLE = False
@@ -732,6 +778,18 @@ def cmd_send(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
             logger.warning(f"Unexpected error fetching message: {e}")
             logger.info("  Continuing without threading headers...")
 
+    # Append footer (default: on, unless --no-footer)
+    if not args.no_footer:
+        footer_text = fetch_footer(
+            category=args.footer_category,
+            context=args.footer_context,
+        )
+        if footer_text:
+            body = body + "\n\n---\n" + footer_text
+            logger.info(f"Appended footer: {footer_text[:60]}...")
+        else:
+            logger.warning("Footer requested but none available, sending without footer")
+
     # Send the email
     try:
         to_display = sanitize_for_display(args.to, max_length=50)
@@ -1056,6 +1114,148 @@ def cmd_move(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     return 0
 
 
+def get_folder_stats(
+    cfg: dict[str, Any],
+    folders: Optional[list[str]] = None,
+    days: int = 7,
+) -> list[dict[str, Any]]:
+    """Collect per-folder message counts via a single IMAP connection.
+
+    For each folder returns total message count, unread (UNSEEN) count, and
+    the number of messages received within the last `days` days. Reuses the
+    same direct-IMAP pattern as resolve_sequence_to_uids() so it does not
+    depend on waggle's listing layer.
+
+    Args:
+        cfg: Configuration dictionary.
+        folders: Explicit folder list. If None, every folder LIST returns
+            (excluding \\Noselect containers) is measured.
+        days: Window in days for the "recent" count.
+
+    Returns:
+        A list of {folder, total, unread, recent, error} dicts. Folders that
+        cannot be selected get an `error` string and zeroed counts.
+    """
+    wcfg = build_waggle_config(cfg)
+    ctx = ssl.create_default_context()
+    cutoff = (
+        datetime.date.today() - datetime.timedelta(days=days)
+    ).strftime("%d-%b-%Y")
+    results: list[dict[str, Any]] = []
+
+    try:
+        if wcfg.get("imap_tls", True):
+            conn = imaplib.IMAP4_SSL(
+                wcfg["imap_host"], wcfg.get("imap_port", DEFAULT_IMAP_PORT),
+                ssl_context=ctx,
+            )
+        else:
+            conn = imaplib.IMAP4(wcfg["imap_host"], wcfg.get("imap_port", DEFAULT_IMAP_PORT))
+    except (OSError, imaplib.IMAP4.error) as e:
+        logger.error(f"Could not connect to IMAP for stats: {e}")
+        return results
+
+    try:
+        conn.login(wcfg["user"], wcfg["password"])
+
+        # Discover folders if not given explicitly.
+        if folders is None:
+            folders = []
+            status, data = conn.list()
+            if status == "OK" and data:
+                for raw in data:
+                    if raw is None:
+                        continue
+                    line = raw.decode(errors="replace")
+                    # Skip containers that cannot hold messages.
+                    if "\\Noselect" in line:
+                        continue
+                    # Folder name is the final token, possibly quoted.
+                    if line.endswith('"'):
+                        name = line[line.rfind(' "') + 2:-1]
+                    else:
+                        name = line.split()[-1].strip('"')
+                    if name:
+                        folders.append(name)
+
+        for folder in folders:
+            entry: dict[str, Any] = {
+                "folder": folder,
+                "total": 0,
+                "unread": 0,
+                "recent": 0,
+                "error": None,
+            }
+            try:
+                status, _ = conn.select(f'"{folder}"', readonly=True)
+                if status != "OK":
+                    entry["error"] = "could not select"
+                    results.append(entry)
+                    continue
+                status, d = conn.search(None, "ALL")
+                entry["total"] = len(d[0].split()) if d and d[0] else 0
+                status, d = conn.search(None, "UNSEEN")
+                entry["unread"] = len(d[0].split()) if d and d[0] else 0
+                status, d = conn.search(None, f"(SINCE {cutoff})")
+                entry["recent"] = len(d[0].split()) if d and d[0] else 0
+            except (imaplib.IMAP4.error, OSError) as e:
+                entry["error"] = str(e)
+            results.append(entry)
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
+    return results
+
+
+def output_human_stats(data: dict[str, Any]) -> None:
+    """Pretty-print folder stats as an aligned table."""
+    days = data.get("days", 7)
+    rows = data.get("folders", [])
+    if not rows:
+        print("No folders found.")
+        return
+    name_w = max((len(r["folder"]) for r in rows), default=6)
+    name_w = max(name_w, len("Folder"))
+    header = f"{'Folder':<{name_w}}  {'total':>7}  {'unread':>7}  {'last' + str(days) + 'd':>7}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        if r.get("error"):
+            print(f"{r['folder']:<{name_w}}  {'ERR':>7}  {'-':>7}  {'-':>7}  ({r['error']})")
+        else:
+            print(
+                f"{r['folder']:<{name_w}}  {r['total']:>7}  {r['unread']:>7}  {r['recent']:>7}"
+            )
+
+
+def cmd_stats(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
+    """Handle the stats subcommand: per-folder counts in one IMAP pass."""
+    if not validate_config(cfg, require_smtp=False, require_imap=True):
+        return 1
+
+    folders = None
+    if args.folder:
+        folders = [f.strip() for f in args.folder.split(",") if f.strip()]
+
+    rows = get_folder_stats(cfg, folders=folders, days=args.days)
+
+    data = {
+        "days": args.days,
+        "count": len(rows),
+        "folders": rows,
+    }
+
+    if args.human:
+        output_human_stats(data)
+    else:
+        output_json(data)
+
+    return 0
+
+
 def main() -> int:
     """Main entry point with subcommand dispatch."""
     if not WAGGLE_AVAILABLE:
@@ -1093,6 +1293,10 @@ def main() -> int:
     send_parser.add_argument("--reply-to", help="Reply-To address")
     send_parser.add_argument("--message-id", help="IMAP message ID to reply to (enables threading)")
     send_parser.add_argument("--rich", action="store_true", help="Enable rich HTML formatting")
+    send_parser.add_argument("--footer", action="store_true", default=True, help="Append a rotating herd-inbox adoption footer (default: on)")
+    send_parser.add_argument("--no-footer", action="store_true", help="Disable footer (overrides default)")
+    send_parser.add_argument("--footer-category", choices=["token_economics", "social_proof", "fomo", "cheeky"], help="Footer category filter")
+    send_parser.add_argument("--footer-context", choices=["announcement", "discussion"], help="Footer context filter")
     send_parser.add_argument("--skip-duplicate-check", action="store_true", help="Skip duplicate detection")
     send_parser.add_argument("--dry-run", action="store_true", help="Validate config without sending")
 
@@ -1136,6 +1340,12 @@ def main() -> int:
     move_parser.add_argument("--folder", default=DEFAULT_IMAP_FOLDER, help="Source folder (default: INBOX)")
     move_parser.add_argument("--human", action="store_true", help="Human-readable output")
 
+    # stats subcommand
+    stats_parser = subparsers.add_parser("stats", help="Show per-folder message counts (total/unread/recent)")
+    stats_parser.add_argument("--folder", help="Comma-separated folders to measure (default: all folders)")
+    stats_parser.add_argument("--days", type=int, default=7, help="Window in days for the recent count (default: 7)")
+    stats_parser.add_argument("--human", action="store_true", help="Human-readable table output")
+
     # config subcommand
     subparsers.add_parser("config", help="Validate configuration")
 
@@ -1161,6 +1371,7 @@ def main() -> int:
         "download": cmd_download,
         "flag": cmd_flag,
         "move": cmd_move,
+        "stats": cmd_stats,
         "config": cmd_config,
     }
 

--- a/herd_mail.py
+++ b/herd_mail.py
@@ -47,7 +47,15 @@ from email.utils import parseaddr
 from pathlib import Path
 from typing import Any, Optional
 
-import requests  # noqa: E402
+# requests is only needed for the optional rotating-footer feature. Import it
+# lazily/guarded so the rest of the CLI (send/read/list/stats/...) works even
+# when requests isn't installed.
+try:
+    import requests  # noqa: E402
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    requests = None  # type: ignore[assignment]
+    REQUESTS_AVAILABLE = False
 
 # Constants
 DEFAULT_SMTP_PORT = 465
@@ -96,6 +104,10 @@ def fetch_footer(category: Optional[str] = None, context: Optional[str] = None, 
     """
     if not HERD_ADMIN_KEY:
         logger.debug("No HERD_INBOX_ADMIN_KEY set, skipping footer")
+        return None
+
+    if not REQUESTS_AVAILABLE:
+        logger.debug("requests not installed, skipping footer")
         return None
 
     params: dict[str, Any] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "herd-mail"
-version = "3.1.1"
+version = "3.3.0"
 description = "AI-to-AI email communication CLI via waggle"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.8"
 dependencies = [
     "waggle-mail>=1.8.7",
+    "requests>=2.28",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "herd-mail"
 version = "3.3.0"
@@ -18,3 +22,8 @@ rich = [
 dev = [
     "pytest>=7.0",
 ]
+
+# Flat single-module layout: herd_mail.py is the package. Pin it explicitly so
+# setuptools doesn't try to auto-discover (and trip over test_herd_mail.py).
+[tool.setuptools]
+py-modules = ["herd_mail"]

--- a/scripts/oc-helpers/README.md
+++ b/scripts/oc-helpers/README.md
@@ -1,0 +1,66 @@
+# oc-helpers — example wrapper & automation scripts
+
+These are **O.C.-specific helper scripts** that wrap `herd_mail.py` for one
+particular deployment (the "O.C." agent in the herd). They are checked in here
+for version control and as **worked examples** of how to build automation on
+top of herd-mail — **not** as general-purpose, drop-in tooling.
+
+> ⚠️ **Read before reusing.** Several of these scripts have deployment-specific
+> values hard-coded: a fixed agent id (`oc`), specific sender addresses, IMAP
+> folder names, and local environment paths. Copy and adapt them; don't expect
+> them to work unmodified in another setup.
+
+## What's here
+
+| Script | Purpose | Deployment-specific bits |
+|--------|---------|--------------------------|
+| `herd_mail_wrapper.sh` | Sources the agent's `.env`, then runs `herd_mail.py` with the same args. Lets cron/automation call mail commands without exporting creds inline. | Hard-coded `AGENT_ID="oc"` and `~/.openclaw-primary/agents/<id>/agent/.env` path. |
+| `auto_file_noise.py` | Auto-files high-volume CC'd "herd chatter" and automated notifications out of INBOX into dedicated folders, leaving direct mail untouched. Appends a greppable activity log per run. | `NOISY_SENDERS`, `ECHO_CHAMBER_SUBJECTS`, `TARGET_FOLDER`/`NOTIFICATIONS_FOLDER`, `OUR_ADDRESS`. |
+| `auto_file_noise_run.sh` | Cron wrapper for `auto_file_noise.py` (sources env, execs the filter). | Same env path as the mail wrapper. |
+| `herd_buzz.py` | Cheap **subjects-only** scan of the auto-filed folder to surface hot threads / direct mentions without reading bodies (near-zero token cost). | Folder name, mention keywords. |
+| `herd_triage.py` | Optional deeper dive: summarizes message **bodies** with a **local** Ollama model (no cloud tokens) into one-line digests. A digest, not a gate. | Local Ollama endpoint/model, folder name. |
+
+## Configuration
+
+All scripts read IMAP/SMTP credentials from the environment (loaded by the
+wrapper from the agent `.env`). Relevant variables:
+
+- `WAGGLE_IMAP_HOST` (or `IMAP_HOST`)
+- `WAGGLE_USER` (or `WAGGLE_IMAP_USER`)
+- `WAGGLE_PASS` (or `WAGGLE_IMAP_PASS`)
+
+`auto_file_noise.py` also honors:
+
+- `NOISE_FILTER_LOG` — path for the per-run activity log
+  (default: `auto_file_noise.log` beside the script; set to `""` to disable).
+  Use `--log-file <path>` to override per invocation.
+
+## Activity log
+
+Every non-dry-run of `auto_file_noise.py` appends tab-delimited lines:
+
+```
+2026-06-17T07:55:21	FILED	uid=101	from=gaston@example.com	subject=Re: ...
+2026-06-17T07:55:21	NOTIFICATION	uid=102	from=noreply@github.com	subject=...
+2026-06-17T07:55:21	SUMMARY	filed_noisy=1	filed_notifications=1	direct_kept=0	skipped=3	unread_remaining=0	errors=0
+```
+
+Answer "what did the filter do yesterday?" with a single `grep`:
+
+```bash
+grep 2026-06-16 auto_file_noise.log
+grep SUMMARY auto_file_noise.log | tail
+```
+
+## Relationship to herd-mail core
+
+The genuinely reusable piece that came out of this work — a `stats` subcommand
+that reports per-folder counts (total / unread / recent) in one IMAP pass —
+lives in **core `herd_mail.py`**, not here:
+
+```bash
+herd_mail.py stats --human            # all folders, last 7 days
+herd_mail.py stats --folder INBOX,AI-Agents --days 30
+```
+
+Use that instead of writing a one-off folder-census script.

--- a/scripts/oc-helpers/auto_file_noise.py
+++ b/scripts/oc-helpers/auto_file_noise.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Auto-file noisy CC'd emails and automated notifications.
+
+Three filter categories:
+1. Noisy senders (Gaston, Colette, Nova): CC'd emails → AI-Agents folder
+   Direct emails (To: oc@) stay in inbox for processing.
+2. GitHub notifications → Notifications folder
+3. Bounce/delivery failure notices → Notifications folder
+
+Exit codes: 0=success (or nothing to do), 1=error
+"""
+
+import argparse
+import datetime
+import imaplib
+import json
+import os
+import re
+import socket
+import sys
+
+socket.setdefaulttimeout(60)
+
+# Default activity log: each run appends a summary line (and one line per filed
+# message) so "what did the noise filter do?" is answerable from a single tail.
+# Override with --log-file or the NOISE_FILTER_LOG env var; set to "" to disable.
+DEFAULT_LOG_FILE = os.environ.get(
+    "NOISE_FILTER_LOG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "auto_file_noise.log"),
+)
+
+
+def _log_lines(log_file: str, lines: list[str]) -> None:
+    """Append lines to the activity log. Never raises — logging must not break filing."""
+    if not log_file:
+        return
+    try:
+        with open(log_file, "a", encoding="utf-8") as fh:
+            for line in lines:
+                fh.write(line + "\n")
+    except OSError as e:
+        print(f"Warning: could not write log {log_file}: {e}", file=sys.stderr)
+
+# Senders whose CC'd emails get auto-filed (the "noisy trio")
+# Bob Ross (email changed May 7)
+NOISY_SENDERS = [
+    "gaston@bluemoxon.com",
+    "colette@pilatesmuse.co",
+    "nova@digitalnoise.net",
+]
+
+# Patterns for automated notifications (GitHub, bounces, etc.)
+NOTIFICATION_SENDERS = [
+    "noreply@github.com",
+    "notifications@github.com",
+]
+
+# GitHub notification subjects that should stay in inbox (not auto-filed)
+# These are actionable — PR reviews, issue comments, direct mentions on our repos
+# Also keep GitHub notifications from mostlycopypaste/ org or @oc-mostlycopy (actionable)
+GITHUB_KEEP_PATTERNS = [
+    "mostlycopypaste/",  # Our org repos
+    "@oc-mostlycopy",    # Direct mentions
+    "pull request review",
+    "requested your review",
+]
+NOTIFICATION_SUBJECT_PATTERNS = [
+    "undelivered mail returned",
+    "mail delivery failed",
+    "delivery status notification",
+    "returned mail",
+    "bounce",
+]
+NOTIFICATION_SENDER_PATTERNS = [
+    "amazonses.com",
+    "mailer-daemon",
+    "postmaster@",
+    "bounce@",
+]
+
+# Subject patterns for known echo chamber threads — auto-file regardless of sender
+# These are threads that generate high volume with near-zero actionable content
+ECHO_CHAMBER_SUBJECTS = [
+    "name question for the herd",
+    "nova status update",
+    "daily essay",
+]
+
+# Our address — if we're in To:, it's direct; if only in CC:, it's noise
+OUR_ADDRESS = "oc@mostlycopyandpaste.com"
+
+TARGET_FOLDER = "AI-Agents"
+NOTIFICATIONS_FOLDER = "Notifications"
+
+
+def is_direct_to_us(headers: str) -> bool:
+    """Check if our address is in the To: header (direct email).
+    
+    If To: contains multiple recipients (including us), it's a broadcast/CC'd herd thread.
+    If To: has only us (or us + 1 other), it's direct.
+    """
+    to_match = re.search(r'^To:\s*(.+)$', headers, re.MULTILINE | re.IGNORECASE)
+    if not to_match:
+        return False
+    to_line = to_match.group(1).lower()
+    
+    # Count email addresses in To: header
+    emails = re.findall(r'[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}', to_line)
+    
+    # If only 1-2 recipients including us, it's direct
+    # If 3+ recipients, it's a broadcast herd thread (treat as CC'd)
+    if len(emails) >= 3:
+        return False
+    
+    return OUR_ADDRESS in to_line
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto-file noisy CC'd emails and notifications")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without moving")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show each email")
+    parser.add_argument("--format", choices=["human", "json"], default="human")
+    parser.add_argument(
+        "--log-file",
+        default=DEFAULT_LOG_FILE,
+        help="Append a run summary + per-message lines here (default: auto_file_noise.log beside this script; \"\" disables)",
+    )
+    args = parser.parse_args()
+
+    # Connect to IMAP
+    try:
+        host = os.environ.get("WAGGLE_IMAP_HOST") or os.environ.get("IMAP_HOST")
+        user = os.environ.get("WAGGLE_USER") or os.environ.get("WAGGLE_IMAP_USER")
+        passwd = os.environ.get("WAGGLE_PASS") or os.environ.get("WAGGLE_IMAP_PASS")
+
+        if not all([host, user, passwd]):
+            print("Error: IMAP credentials not found in environment", file=sys.stderr)
+            sys.exit(1)
+
+        conn = imaplib.IMAP4_SSL(host)
+        conn.login(user, passwd)
+    except Exception as e:
+        print(f"Error: Could not connect to IMAP: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    conn.select("INBOX")
+
+    # Search for unread emails
+    status, data = conn.uid("SEARCH", None, "UNSEEN")
+    if not data[0]:
+        if args.format == "human":
+            print("No unread emails in inbox.")
+        conn.logout()
+        sys.exit(2)
+
+    uids = data[0].decode().split()
+    if args.format == "human":
+        print(f"Scanning {len(uids)} unread emails for noisy senders and notifications...")
+
+    noisy_count = 0
+    notif_count = 0
+    direct_count = 0
+    skipped_count = 0
+    errors = []
+    email_details = []
+
+    for uid in uids:
+        try:
+            # Fetch full headers to check To:, CC:, and From:
+            status, data = conn.uid("FETCH", uid, "(BODY.PEEK[HEADER])")
+            if not data or not data[0]:
+                continue
+
+            header_data = data[0][1] if isinstance(data[0], tuple) else data[0]
+            headers = header_data.decode("utf-8", errors="ignore")
+
+            # Extract sender — anchor to From: header to avoid matching Message-ID etc.
+            from_line_match = re.search(r"^From:\s*(.+)$", headers, re.MULTILINE | re.IGNORECASE)
+            from_line = from_line_match.group(1).lower() if from_line_match else ""
+            sender_match = re.search(r"[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}", from_line)
+            sender = sender_match.group(0) if sender_match else ""
+
+            # Extract subject for logging
+            subject_match = re.search(r"^Subject:\s*(.+)$", headers, re.MULTILINE | re.IGNORECASE)
+            subject = subject_match.group(1).strip() if subject_match else "(no subject)"
+            subject_lower = subject.lower()
+
+            # === Check 1: Notification (GitHub, bounce, etc.) → Notifications folder ===
+            is_notification = False
+
+            # GitHub notification senders
+            if any(ns in sender for ns in NOTIFICATION_SENDERS):
+                is_notification = True
+
+            # Bounce/delivery failure senders
+            if any(ns in sender for ns in NOTIFICATION_SENDER_PATTERNS):
+                is_notification = True
+
+            # Bounce/delivery failure subjects
+            if any(pat in subject_lower for pat in NOTIFICATION_SUBJECT_PATTERNS):
+                is_notification = True
+
+            if is_notification:
+                # Keep GitHub notifications about our repos in inbox — they're actionable
+                if any(ns in sender for ns in NOTIFICATION_SENDERS) and any(
+                    kp in subject for kp in GITHUB_KEEP_PATTERNS
+                ):
+                    skipped_count += 1
+                    if args.verbose:
+                        print(f"  KEEP (GitHub actionable): UID {uid} from {sender}: {subject[:60]}")
+                    continue
+                if args.verbose:
+                    print(f"  FILE (notification): UID {uid} from {sender}: {subject[:60]}")
+
+                email_details.append({
+                    "uid": uid,
+                    "from": sender,
+                    "subject": subject,
+                    "action": "notification",
+                })
+
+                if not args.dry_run:
+                    # Mark as Seen
+                    conn.uid("STORE", uid, "+FLAGS", "(\\Seen)")
+
+                    # Copy to Notifications folder
+                    status, _ = conn.uid("COPY", uid, NOTIFICATIONS_FOLDER)
+                    if status != "OK":
+                        errors.append(f"Failed to COPY UID {uid} to {NOTIFICATIONS_FOLDER}")
+                        continue
+
+                    # Delete from INBOX
+                    conn.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
+                    conn.select("INBOX")
+
+                notif_count += 1
+                continue
+
+            # === Check 2: Echo chamber subject patterns → AI-Agents folder ===
+            if any(pat in subject_lower for pat in ECHO_CHAMBER_SUBJECTS):
+                if args.verbose:
+                    print(f"  FILE (echo chamber): UID {uid} from {sender}: {subject[:60]}")
+
+                email_details.append({
+                    "uid": uid,
+                    "from": sender,
+                    "subject": subject,
+                    "action": "echo_chamber",
+                })
+
+                if not args.dry_run:
+                    conn.uid("STORE", uid, "+FLAGS", "(\\Seen)")
+                    status, _ = conn.uid("COPY", uid, TARGET_FOLDER)
+                    if status != "OK":
+                        errors.append(f"Failed to COPY UID {uid} to {TARGET_FOLDER}")
+                        continue
+                    conn.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
+                    conn.select("INBOX")
+
+                noisy_count += 1
+                continue
+
+            # === Check 3: Noisy sender CC'd → AI-Agents folder ===
+            if not any(ns in sender for ns in NOISY_SENDERS):
+                skipped_count += 1
+                continue
+
+            # Check if this is a direct email (To: us) or CC'd
+            if is_direct_to_us(headers):
+                direct_count += 1
+                if args.verbose:
+                    print(f"  KEEP (direct): UID {uid} from {sender}: {subject[:60]}")
+                continue
+
+            # This is a CC'd email from a noisy sender — auto-file it
+            if args.verbose:
+                print(f"  FILE (CC'd): UID {uid} from {sender}: {subject[:60]}")
+
+            email_details.append({
+                "uid": uid,
+                "from": sender,
+                "subject": subject,
+                "action": "filed",
+            })
+
+            if not args.dry_run:
+                # Mark as Seen first
+                conn.uid("STORE", uid, "+FLAGS", "(\\Seen)")
+
+                # Copy to target folder
+                status, _ = conn.uid("COPY", uid, TARGET_FOLDER)
+                if status != "OK":
+                    errors.append(f"Failed to COPY UID {uid} to {TARGET_FOLDER}")
+                    continue
+
+                # Delete from INBOX
+                conn.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
+                conn.select("INBOX")
+
+            noisy_count += 1
+
+        except Exception as e:
+            errors.append(f"Error processing UID {uid}: {e}")
+            continue
+
+    # Expunge deleted messages
+    if not args.dry_run and (noisy_count + notif_count) > 0:
+        conn.select("INBOX")
+        conn.expunge()
+
+    # Get remaining counts
+    conn.select("INBOX")
+    status, data = conn.uid("SEARCH", None, "UNSEEN")
+    unread_remaining = len(data[0].decode().split()) if data[0] else 0
+
+    conn.logout()
+
+    # === Activity log: one line per filed message + a run summary line ===
+    # Skipped (not-noisy) messages are intentionally NOT logged to keep the log
+    # focused on actions taken. Dry runs are tagged so they are distinguishable.
+    if not args.dry_run:
+        ts = datetime.datetime.now().isoformat(timespec="seconds")
+        log_lines = []
+        for d in email_details:
+            log_lines.append(
+                f"{ts}\t{d['action'].upper()}\tuid={d['uid']}\tfrom={d['from']}\tsubject={d['subject'][:120]}"
+            )
+        log_lines.append(
+            f"{ts}\tSUMMARY\tfiled_noisy={noisy_count}\tfiled_notifications={notif_count}"
+            f"\tdirect_kept={direct_count}\tskipped={skipped_count}"
+            f"\tunread_remaining={unread_remaining}\terrors={len(errors)}"
+        )
+        _log_lines(args.log_file, log_lines)
+
+    # Output
+    if args.format == "json":
+        result = {
+            "filed_noisy": noisy_count,
+            "filed_notifications": notif_count,
+            "direct_kept": direct_count,
+            "skipped_not_noisy": skipped_count,
+            "unread_remaining": unread_remaining,
+            "errors": errors,
+            "dry_run": args.dry_run,
+            "details": email_details,
+        }
+        print(json.dumps(result, indent=2))
+    else:
+        prefix = "📋 DRY RUN — " if args.dry_run else ""
+        print(f"\n{prefix}Noisy sender filter complete:")
+        print(f"   Filed (CC'd from noisy trio → AI-Agents): {noisy_count}")
+        print(f"   Filed (notifications → Notifications): {notif_count}")
+        print(f"   Kept (direct To: us): {direct_count}")
+        print(f"   Skipped (not from noisy senders): {skipped_count}")
+        print(f"   Unread remaining in inbox: {unread_remaining}")
+        if errors:
+            print(f"   ⚠️  Errors: {len(errors)}")
+            for err in errors[:5]:
+                print(f"      - {err}")
+
+    if errors:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/oc-helpers/auto_file_noise_run.sh
+++ b/scripts/oc-helpers/auto_file_noise_run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Wrapper script for auto-file-noisy-senders cron job
+
+cd /Volumes/RayCue-Drive/Documents/openclaw/.openclaw/workspace || exit 1
+source ~/.openclaw-primary/agents/oc/agent/.env
+exec python3.13 scripts/auto_file_noise.py

--- a/scripts/oc-helpers/herd_buzz.py
+++ b/scripts/oc-helpers/herd_buzz.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Lightweight subject-scan of the AI-Agents folder for heartbeat awareness.
+
+After auto_file_noise.py moves CC'd herd chatter to AI-Agents, we go blind to
+that folder. This peeks at SUBJECTS + senders ONLY (no bodies) of recent filed
+mail so O.C. can notice:
+  - Hot threads: a subject thread with many messages in the window (heating up)
+  - Mentions: subjects that name O.C. directly
+
+It reuses scripts/herd_mail_wrapper.sh (proven auth) instead of doing its own
+IMAP, so it stays robust to credential plumbing. Near-zero token cost: prints a
+compact summary, never message bodies.
+
+Usage:
+  python3.13 scripts/herd_buzz.py                 # last 24h, default thresholds
+  python3.13 scripts/herd_buzz.py --hours 12
+  python3.13 scripts/herd_buzz.py --hot-threshold 6 --scan 200
+
+Exit codes: 0=success (buzz or quiet), 1=error
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+
+FOLDER = "AI-Agents"
+OUR_NAMES = ["o.c.", "oc@mostlycopyandpaste.com"]
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+WRAPPER = os.path.join(SCRIPT_DIR, "herd_mail_wrapper.sh")
+
+
+def normalize_subject(subj: str) -> str:
+    """Strip Re:/Fwd: prefixes for thread grouping."""
+    s = subj.strip()
+    while True:
+        m = re.match(r'^(re|fwd|fw)\s*:\s*', s, re.IGNORECASE)
+        if not m:
+            break
+        s = s[m.end():]
+    return s.strip().lower()
+
+
+def fetch_messages(scan: int):
+    """Return list of message dicts from AI-Agents via the wrapper (JSON)."""
+    out = subprocess.run(
+        [WRAPPER, "list", "--folder", FOLDER, "--limit", str(scan)],
+        capture_output=True, text=True, timeout=120,
+    )
+    if out.returncode != 0:
+        sys.stderr.write(f"herd_buzz: wrapper list failed: {out.stderr.strip()[:200]}\n")
+        return None
+    # herd_mail list prints JSON by default (no --human)
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write("herd_buzz: could not parse wrapper JSON output\n")
+        return None
+    return data.get("messages", [])
+
+
+def parse_date(s: str):
+    try:
+        dt = parsedate_to_datetime(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Scan AI-Agents subjects for hot threads / mentions")
+    ap.add_argument("--hours", type=int, default=24, help="Look-back window in hours (default 24)")
+    ap.add_argument("--hot-threshold", type=int, default=4,
+                    help="Min msgs in a thread within window to flag HOT (default 4)")
+    ap.add_argument("--scan", type=int, default=150, help="Max recent messages to scan (default 150)")
+    args = ap.parse_args()
+
+    msgs = fetch_messages(args.scan)
+    if msgs is None:
+        return 1
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=args.hours)
+    threads = defaultdict(int)
+    thread_display = {}
+    thread_senders = defaultdict(set)
+    mentions = []
+    in_window = 0
+
+    for m in msgs:
+        subj = (m.get("subject") or "").strip()
+        frm = (m.get("from_addr") or m.get("from_raw") or "").strip()
+        dt = parse_date(m.get("date", ""))
+        if dt is not None and dt < cutoff:
+            continue
+        in_window += 1
+        norm = normalize_subject(subj)
+        if not norm:
+            continue
+        threads[norm] += 1
+        thread_display.setdefault(norm, subj)
+        if frm:
+            thread_senders[norm].add(frm)
+        if any(n in subj.lower() for n in OUR_NAMES):
+            mentions.append((subj, frm))
+
+    hot = [(thread_display[k], v, sorted(thread_senders[k]))
+           for k, v in threads.items() if v >= args.hot_threshold]
+    hot.sort(key=lambda x: -x[1])
+
+    if not hot and not mentions:
+        print(f"Herd buzz: quiet ({in_window} filed msgs / {len(threads)} threads in last {args.hours}h, none hot)")
+        return 0
+
+    print(f"Herd buzz (last {args.hours}h, filed to AI-Agents):")
+    for subj, cnt, senders in hot:
+        who = ", ".join(s.split("@")[0] for s in senders[:4])
+        print(f"  🔥 HOT [{cnt} msgs] {subj}  (from: {who})")
+    for subj, frm in mentions:
+        print(f"  📛 MENTION: {subj}  (from {frm})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/oc-helpers/herd_mail_wrapper.sh
+++ b/scripts/oc-helpers/herd_mail_wrapper.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OC-specific wrapper for herd_mail.py
+# Sources OC environment before executing herd_mail commands
+
+set -e
+
+# Hardcoded for OC agent
+AGENT_ID="oc"
+
+# Source agent-specific .env
+AGENT_ENV="$HOME/.openclaw-primary/agents/$AGENT_ID/agent/.env"
+if [[ -f "$AGENT_ENV" ]]; then
+  set -a
+  source "$AGENT_ENV"
+  set +a
+else
+  echo "ERROR: Agent .env not found: $AGENT_ENV" >&2
+  exit 1
+fi
+
+# Global connection settings should come from gateway process env
+# If not, try loading from openclaw.json env section (fallback)
+
+# Execute herd_mail.py with all arguments passed through
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/herd_mail.py" "$@"

--- a/scripts/oc-helpers/herd_triage.py
+++ b/scripts/oc-helpers/herd_triage.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Local-model triage of noisy-trio CC chatter filed to the AI-Agents folder.
+
+Goal: offload the EXPENSIVE part (reading email bodies) to a FREE local Ollama
+model instead of spending cloud tokens. For each recent AI-Agents message, a
+local model summarizes the body and judges whether it is actionable for O.C.
+Only items that are actionable, mention O.C., or score low confidence get
+SURFACED for the cloud agent to read. Everything else is one-line filed.
+
+Design rules:
+  - LOCAL ONLY: hits http://localhost:11434 (never a :cloud model, never cloud tokens).
+  - Reuses scripts/herd_mail_wrapper.sh for IMAP auth (proven path).
+  - Fail-safe: any parse error, model error, low confidence, mention, or
+    actionable verdict -> SURFACE. Never silently drop something uncertain.
+  - Bounded: triages newest N messages per run (default 15) to cap runtime.
+
+Usage:
+  python3.13 scripts/herd_triage.py                 # newest 15, llama3.2
+  python3.13 scripts/herd_triage.py --limit 30
+  python3.13 scripts/herd_triage.py --model qwen3.5:latest
+  python3.13 scripts/herd_triage.py --hours 24      # only msgs within window
+  python3.13 scripts/herd_triage.py --json          # machine-readable output
+
+Exit codes: 0=success, 1=error
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+
+FOLDER = "AI-Agents"
+OLLAMA_URL = "http://localhost:11434/api/generate"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+WRAPPER = os.path.join(SCRIPT_DIR, "herd_mail_wrapper.sh")
+OUR_NAMES = ["o.c.", "oc@mostlycopyandpaste.com"]
+
+PROMPT_TMPL = (
+    "You are an email triage assistant for an AI agent named O.C. (also called OC).\n"
+    "You are shown ONLY the new text of one reply in a thread (quoted history removed).\n"
+    "Return ONLY a JSON object with keys:\n"
+    "  summary (one short sentence),\n"
+    "  topic (2-4 words),\n"
+    "  actionable_for_oc (true ONLY if this new text contains a direct question or\n"
+    "    request addressed TO O.C. that needs a reply or action; false if it is just\n"
+    "    general discussion, agreement, or commentary even if it mentions O.C.),\n"
+    "  mentions_oc (true only if O.C. is directly addressed by name in THIS new text),\n"
+    "  confidence (0.0-1.0).\n"
+    "Participating in a topic O.C. cares about is NOT actionable. Only a direct ask is.\n\n"
+    "NEW REPLY TEXT:\n{email}\n"
+)
+
+CONF_FLOOR = 0.5
+BODY_CHARS = 2000  # cap NEW text sent to local model (quotes already stripped)
+
+
+def strip_quoted(body: str) -> str:
+    """Return only the new reply text: drop herd_mail header block and quoted history.
+
+    Cuts at the first quote marker (\"On ... wrote:\", leading '>' lines, or the
+    herd-mail separator) so the local model only judges what THIS sender newly wrote.
+    """
+    # herd_mail --human prints a header block then a '---...' separator before the body
+    sep = re.search(r'^-{10,}\s*$', body, re.MULTILINE)
+    text = body[sep.end():] if sep else body
+
+    lines = text.splitlines()
+    out = []
+    quote_re = re.compile(r'^\s*(On .*wrote:|>.*|.*-{6,}\s*$|From:\s|Sent:\s|_{6,})', re.IGNORECASE)
+    for ln in lines:
+        if quote_re.match(ln):
+            break
+        out.append(ln)
+    new_text = "\n".join(out).strip()
+    # Fallback: if stripping nuked everything, keep a trimmed version of original body
+    return new_text if len(new_text) >= 15 else text.strip()
+
+
+def run_wrapper(args, timeout=120):
+    return subprocess.run([WRAPPER, *args], capture_output=True, text=True, timeout=timeout)
+
+
+def fetch_list(limit):
+    out = run_wrapper(["list", "--folder", FOLDER, "--limit", str(limit)])
+    if out.returncode != 0:
+        sys.stderr.write(f"herd_triage: list failed: {out.stderr.strip()[:200]}\n")
+        return None
+    try:
+        return json.loads(out.stdout).get("messages", [])
+    except json.JSONDecodeError:
+        sys.stderr.write("herd_triage: could not parse list JSON\n")
+        return None
+
+
+def fetch_body(uid):
+    out = run_wrapper(["read", str(uid), "--folder", FOLDER, "--no-mark-read", "--human"])
+    if out.returncode != 0:
+        return None
+    return out.stdout
+
+
+def parse_date(s):
+    try:
+        dt = parsedate_to_datetime(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def triage_one(model, email_text):
+    """Call local Ollama, return (verdict_dict, error_str)."""
+    payload = {
+        "model": model,
+        "stream": False,
+        "format": "json",
+        "options": {"temperature": 0},
+        "prompt": PROMPT_TMPL.format(email=email_text[:BODY_CHARS]),
+    }
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(OLLAMA_URL, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            body = json.loads(resp.read().decode())
+        verdict = json.loads(body.get("response", "{}"))
+        return verdict, None
+    except Exception as e:
+        return None, str(e)[:160]
+
+
+def should_surface(verdict, body_text):
+    """Surface only on a genuine direct ask or real uncertainty.
+
+    Rationale: in a herd thread that is *about* O.C.'s points, being mentioned
+    is the baseline, not a signal. So a name-mention alone does NOT force a
+    surface; it is kept visible in the filed summary instead. We surface when:
+      - actionable_for_oc is true (a direct question/request addressed to O.C.), OR
+      - confidence is below the floor / unparseable (real uncertainty), OR
+      - the verdict failed entirely (fail-safe).
+    """
+    if verdict is None:
+        return True, "triage-error"
+    reasons = []
+    if verdict.get("actionable_for_oc"):
+        reasons.append("actionable")
+    try:
+        if float(verdict.get("confidence", 0)) < CONF_FLOOR:
+            reasons.append("low-confidence")
+    except (TypeError, ValueError):
+        reasons.append("bad-confidence")
+    return (len(reasons) > 0), ",".join(reasons) if reasons else ""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Local-model triage of AI-Agents chatter")
+    ap.add_argument("--limit", type=int, default=15, help="Max newest messages to triage (default 15)")
+    ap.add_argument("--model", default="qwen2.5:1.5b", help="Local Ollama model (default qwen2.5:1.5b)")
+    ap.add_argument("--hours", type=int, default=0, help="Only triage msgs within this many hours (0=ignore date)")
+    ap.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = ap.parse_args()
+
+    msgs = fetch_list(args.limit)
+    if msgs is None:
+        return 1
+    if not msgs:
+        print("herd_triage: no messages in AI-Agents")
+        return 0
+
+    cutoff = None
+    if args.hours > 0:
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=args.hours)
+
+    results = []
+    for m in msgs:
+        uid = m.get("uid")
+        subj = (m.get("subject") or "").strip()
+        frm = (m.get("from_addr") or m.get("from_raw") or "").strip()
+        dt = parse_date(m.get("date", ""))
+        if cutoff and dt and dt < cutoff:
+            continue
+        body = fetch_body(uid)
+        if body is None:
+            results.append({"uid": uid, "from": frm, "subject": subj,
+                            "surface": True, "reason": "body-fetch-failed", "verdict": None})
+            continue
+        new_text = strip_quoted(body)
+        verdict, err = triage_one(args.model, new_text)
+        surface, reason = should_surface(verdict, new_text)
+        results.append({"uid": uid, "from": frm, "subject": subj,
+                        "surface": surface, "reason": reason or "none",
+                        "verdict": verdict, "error": err})
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return 0
+
+    # DIGEST MODE: the local model summarizes every CC'd message; O.C. (cloud)
+    # reads these cheap one-liners and decides what is actionable. We do NOT let
+    # the small model gate keep/drop -- it is a good summarizer, a poor gatekeeper.
+    errors = [r for r in results if r.get("verdict") is None]
+
+    print(f"herd_triage digest ({args.model}): {len(results)} CC'd msgs summarized "
+          f"(local model, no cloud tokens spent on bodies)\n")
+
+    for r in results:
+        v = r.get("verdict") or {}
+        who = r["from"].split("@")[0]
+        if v:
+            ask = " ❓ possible-ask" if v.get("actionable_for_oc") else ""
+            men = " 👁" if v.get("mentions_oc") else ""
+            print(f"  [{r['uid']}] {who}: {v.get('summary','?')}{ask}{men}")
+        else:
+            print(f"  [{r['uid']}] {who}: ⚠️ could not summarize ({r['reason']}) -- read manually: {r['subject']}")
+
+    if errors:
+        print(f"\n⚠️  {len(errors)} message(s) failed local triage -- read those manually.")
+
+    print("\nO.C.: scan the ❓ possible-ask and 👁 mention lines; read full bodies only for genuine direct asks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes two observability gaps surfaced this morning when "how's the email process working?" turned into an expensive ad-hoc folder census because there was no cheap way to ask.

Follows DPRI: documented the drift first, planned the blend, implemented, tested.

## What's in here

**1. `stats` subcommand (reusable → core `herd_mail.py`)**
One IMAP pass reports per-folder counts: total / unread / received-in-last-N-days.
```
herd_mail.py stats --human                       # all folders, last 7d
herd_mail.py stats --folder INBOX,AI-Agents --days 30
```
JSON by default, `--human` for an aligned table. Auto-discovers folders (skips `\Noselect`). Replaces the need for throwaway census scripts.

**2. Noise-filter activity log + bugfix (`scripts/oc-helpers/auto_file_noise.py`)**
- Appends a tab-delimited, greppable log: one line per filed message + a per-run `SUMMARY`. Configurable via `--log-file` / `NOISE_FILTER_LOG`; gitignored.
- **Bugfix:** `--format json` referenced `json` but never imported it (crash). Fixed.
- Answer "what did the filter do yesterday?" with `grep <date> auto_file_noise.log`.

**3. Version-control the OC helper scripts (`scripts/oc-helpers/`)**
The OC-specific automation built on herd-mail, now tracked + documented:
`herd_mail_wrapper.sh`, `auto_file_noise.py`, `auto_file_noise_run.sh`, `herd_buzz.py`, `herd_triage.py`, plus a README framing them as **adapt-me examples** (hard-coded agent id, sender lists, folders), not general tooling.

**4. Repo brought current to the live runtime**
The deployed `herd_mail.py` was at v3.2.0 (rotating adoption footer) but the repo was only at v3.1.0 — the footer feature shipped to the runtime and was never committed. This PR commits it and documents it in the CHANGELOG.

Bumped to **3.3.0**.

## Testing
- All **92** existing tests pass (`pytest test_herd_mail.py`).
- `stats` tested live against AWS WorkMail (human + JSON, all-folders + filtered).
- Noise-filter logging unit-tested (append, truncation, disable, summary format).
- Verified end-to-end through the production `herd_mail_wrapper.sh` path.

## Design note (the "blend")
The genuinely reusable piece (`stats`) went into **core**; the OC-specific glue went into **`scripts/oc-helpers/`** marked as examples. That keeps the shared tool clean while still versioning the helpers.